### PR TITLE
Tweaked current DIR detection

### DIFF
--- a/bin/mage
+++ b/bin/mage
@@ -1,8 +1,7 @@
 #!/bin/sh
 #VERSION:0.9.10
 
-SCRIPT=$(readlink -f $0)
-DIR=$(dirname $SCRIPT)
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 PHP_BIN=$(which php) 
 
 $PHP_BIN -d safe_mode=Off -f $DIR/mage.php -- $@


### PR DESCRIPTION
The `bin/mage` script doesn't work for me. The problem is the current DIR detection performed by the following lines:

```
SCRIPT=$(readlink $0)
DIR=$(dirname $SCRIPT)
```

Replacing those lines by the following solves the problem for me:

```
DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
```

Source: http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in

Magallanes version: 0.9.10
OS: Mac OS X
Shell: zsh 4.3.9
