### PR TITLE
Removed cache:clear command from Warmup task

### DIFF
--- a/Mage/Task/BuiltIn/Symfony2/CacheWarmup.php
+++ b/Mage/Task/BuiltIn/Symfony2/CacheWarmup.php
@@ -6,15 +6,12 @@ class Mage_Task_BuiltIn_Symfony2_CacheWarmup
     {
         return 'Symfony v2 - Cache Warmup [built-in]';
     }
-        
+
     public function run()
     {
-        $command = 'app/console cache:clear';
-        $result = $this->_runLocalCommand($command);
-        
         $command = 'app/console cache:warmup';
-        $result = $result && $this->_runLocalCommand($command);
-        
+        $result = $this->_runLocalCommand($command);
+
         return $result;
     }
 }


### PR DESCRIPTION
The command `cache:clear` already warms up the cache, unless you use the option `--no-warmup`.

Probably would be good to dedicate this task to the warmup, as it is not always necessary clear the cache before executing it.
