### PR TITLE
Adds "ssh_needs_tty" general parameter, and rsync copy option

### DIFF
--- a/Mage/Command/BuiltIn/InitCommand.php
+++ b/Mage/Command/BuiltIn/InitCommand.php
@@ -73,13 +73,15 @@ class InitCommand extends AbstractCommand
 				'%notificationEnabled%',
 				'%loggingEnabled%',
 				'%maxlogs%',
+				'%ssh_needs_tty%',
 			),
 			array(
 				$projectName,
 				$notificationEmail,
 				$notificationEnabled,
 				'true',
-				30
+				30,
+				'false'
 			),
 			$this->getGeneralConfigTemplate()
     	);
@@ -98,7 +100,8 @@ class InitCommand extends AbstractCommand
                   . 'email: %notificationEmail%' . PHP_EOL
                   . 'notifications: %notificationEnabled%' . PHP_EOL
                   . 'logging: %loggingEnabled%' . PHP_EOL
-                  . 'maxlogs: %maxlogs%' . PHP_EOL;
+                  . 'maxlogs: %maxlogs%' . PHP_EOL
+                  . 'ssh_needs_tty: %ssh_needs_tty%' . PHP_EOL;
 
     	return $template;
     }

--- a/Mage/Task/AbstractTask.php
+++ b/Mage/Task/AbstractTask.php
@@ -188,8 +188,11 @@ abstract class AbstractTask
         } else {
             $releasesDirectory = '';
         }
+        
+        // if general.yml includes "ssy_needs_tty: true", then add "-t" to the ssh command
+        $needs_tty = ($this->getConfig()->general('ssh_needs_tty',false) ? "-t" : "");
 
-        $localCommand = 'ssh -p ' . $this->getConfig()->getHostPort() . ' '
+        $localCommand = 'ssh ' . $needs_tty . ' -p ' . $this->getConfig()->getHostPort() . ' '
                       . '-q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no '
                       . $this->getConfig()->deployment('user') . '@' . $this->getConfig()->getHostName() . ' '
                       . '"cd ' . rtrim($this->getConfig()->deployment('to'), '/') . $releasesDirectory . ' && '


### PR DESCRIPTION
I ran into an issue where commands were failing due to an "stdin: is not a tty" messages from the host.  To resolve, I added a general flag "ssh_needs_tty", which adds "-t" to the ssh command.

Additionally, when using rsync and a large set of files, I added an additional flag to the deployment options which first copies the prior release to the new release, then rsync's the new release.

```
deployment:
  .....
  strategy: rsync
  rsync: { copy: true }
```

Using this flag, my deployment goes from:

```
(snip)
Finished Magallanes

real    1m6.098s
user    0m5.440s
sys     0m0.724s
```

to this:

```
(snip)
Finished Magallanes

real    0m21.263s
user    0m2.032s
sys     0m0.484s
```
