### PR TITLE
strategy git-rebase is enabled

### DIFF
--- a/Mage/Command/BuiltIn/DeployCommand.php
+++ b/Mage/Command/BuiltIn/DeployCommand.php
@@ -310,7 +310,11 @@ class DeployCommand extends AbstractCommand implements RequiresEnvironment
     			    case 'targz':
     			    	$deployStrategy = 'deployment/strategy/tar-gz';
     			    	break;
-
+                            
+                            case 'git-rebase':
+    			    	$deployStrategy = 'deployment/strategy/git-rebase';
+    			    	break;
+                            
     			    case 'guess':
     			    default:
     			    	if ($this->getConfig()->release('enabled', false) == true) {

--- a/Mage/Task/BuiltIn/Deployment/Strategy/GitRebaseTask.php
+++ b/Mage/Task/BuiltIn/Deployment/Strategy/GitRebaseTask.php
@@ -34,13 +34,13 @@ class GitRebaseTask extends AbstractTask implements IsReleaseAware
      * @see \Mage\Task\AbstractTask::run()
      */
     public function run()
-    {
-    	$branch = $this->getParameter('branch');
-    	$remote = $this->getParameter('remote');
-
+    {        
+    	$branch = $this->getParameter('branch', 'master');
+    	$remote = $this->getParameter('remote', 'origin');
+                
     	// Fetch Remote
         $command = 'git fetch ' . $remote;
-        $result = $this->runCommandRemote($command) && $result;
+        $result = $this->runCommandRemote($command);
 
         // Checkout
         $command = 'git checkout ' . $branch;


### PR DESCRIPTION
Although git-rebase is documented as a deployment strategy and the GitRebaseTask.php task  is implemented, it is not enabled since it does not appear in the strategy switch. This pull request solves this problem.
