### PR TITLE
Add ability to use rsync rather than cp on remote

### DIFF
--- a/Mage/Task/BuiltIn/Deployment/Strategy/RsyncTask.php
+++ b/Mage/Task/BuiltIn/Deployment/Strategy/RsyncTask.php
@@ -85,7 +85,11 @@ class RsyncTask extends AbstractTask implements IsReleaseAware
                 // If deployment configuration is rsync, include a flag to simply sync the deltas between the prior release
                 // rsync: { copy: yes }
                 $rsync_copy = $this->getConfig()->deployment('rsync');
-                if ( $rsync_copy && is_array($rsync_copy) && $rsync_copy['copy'] ) {
+                // If copy_tool_rsync, use rsync rather than cp for finer control of what is copied
+                if ( $rsync_copy && is_array($rsync_copy) && $rsync_copy['copy'] && isset($rsync_copy['copy_tool_rsync']) ) {
+                    $this->runCommandRemote("rsync -a {$this->excludes(array_merge($excludes, $rsync_copy['rsync_excludes']))} "
+                    . "$releasesDirectory/$currentRelease/ $releasesDirectory/{$this->getConfig()->getReleaseId()}");
+                } elseif ( $rsync_copy && is_array($rsync_copy) && $rsync_copy['copy'] ) {
                     $this->runCommandRemote('cp -R ' . $releasesDirectory . '/' . $currentRelease . ' ' . $releasesDirectory . '/' . $this->getConfig()->getReleaseId());
                 } else {
                     $this->runCommandRemote('mkdir -p ' . $releasesDirectory . '/' . $this->getConfig()->getReleaseId());


### PR DESCRIPTION
This enables finer control (via excludes) when seeding the destination
directory for rsync. Because we know we have rsync available, we can use
rsync rather than cp by using configuration like this example:

```
  strategy: rsync
  rsync:
    copy: true
    copy_tool_rsync: true
    rsync_excludes: ["assets", "silverstripe-cache"]
```

The default tool remains cp, so this change is backward-compatible.
