### PR TITLE
add user data and message to lock command

### DIFF
--- a/Mage/Command/BuiltIn/DeployCommand.php
+++ b/Mage/Command/BuiltIn/DeployCommand.php
@@ -104,6 +104,7 @@ class DeployCommand extends AbstractCommand implements RequiresEnvironment
     	$lockFile = '.mage/' . $this->getConfig()->getEnvironment() . '.lock';
     	if (file_exists($lockFile)) {
     		Console::output('<red>This environment is locked!</red>', 1, 2);
+                echo file_get_contents($lockFile);
     		return;
     	}
 

--- a/Mage/Command/BuiltIn/LockCommand.php
+++ b/Mage/Command/BuiltIn/LockCommand.php
@@ -27,8 +27,20 @@ class LockCommand extends AbstractCommand implements RequiresEnvironment
 	 */
     public function run()
     {
+        Console::output('Your name (enter to leave blank): ', 0, 0);
+        $name = Console::readInput();
+        Console::output('Your email (enter to leave blank): ', 0, 0);
+        $email = Console::readInput();
+        Console::output('Reason of lock (enter to leave blank): ', 0, 0);
+        $reason = Console::readInput();
+
+        $lockmsg = PHP_EOL;
+        if ($name) $lockmsg .= 'Locked by ' . $name . ' ';
+        if ($email) $lockmsg .= '(' . $email . ')';
+        if ($reason) $lockmsg .= PHP_EOL . $reason . PHP_EOL;
+
         $lockFile = '.mage/' . $this->getConfig()->getEnvironment() . '.lock';
-        file_put_contents($lockFile, 'Locked environment at date: ' . date('Y-m-d H:i:s'));
+        file_put_contents($lockFile, 'Locked environment at date: ' . date('Y-m-d H:i:s') . $lockmsg);
 
         Console::output('Locked deployment to <light_purple>' . $this->getConfig()->getEnvironment() . '</light_purple> environment', 1, 2);
     }

--- a/Mage/Command/BuiltIn/ReleasesCommand.php
+++ b/Mage/Command/BuiltIn/ReleasesCommand.php
@@ -37,6 +37,7 @@ class ReleasesCommand extends AbstractCommand implements RequiresEnvironment
         $lockFile = '.mage/' . $this->getConfig()->getEnvironment() . '.lock';
         if (file_exists($lockFile) && ($subcommand == 'rollback')) {
             Console::output('<red>This environment is locked!</red>', 1, 2);
+            echo file_get_contents($lockFile);
             return null;
         }
 

--- a/Mage/Command/BuiltIn/RollbackCommand.php
+++ b/Mage/Command/BuiltIn/RollbackCommand.php
@@ -37,6 +37,7 @@ class RollbackCommand extends AbstractCommand implements RequiresEnvironment
         $lockFile = '.mage/' . $this->getConfig()->getEnvironment() . '.lock';
         if (file_exists($lockFile) && ($subcommand == 'rollback')) {
             Console::output('<red>This environment is locked!</red>', 1, 2);
+            echo file_get_contents($lockFile);
             return null;
         }
 

--- a/Mage/Console.php
+++ b/Mage/Console.php
@@ -228,6 +228,18 @@ class Console
     }
 
     /**
+     * Read String From Prompt
+     */
+    public static function readInput()
+    {
+        $fp = fopen("php://stdin","r");
+        $line = '';
+        $line = fgets($fp);
+
+        return rtrim($line);
+    }
+
+    /**
      * Check Logs
      * @param \Mage\Config $config
      */
@@ -252,4 +264,5 @@ class Console
         	}
         }
     }
+
 }


### PR DESCRIPTION
This is a small change, but interesting for known the reason of the lock, and can contact the person who made the lock.

```
[rodmen@localhost Magallanes]$ bin/mage lock to:env
Starting Magallanes

Your name (enter to leave blank): Rodrigo Mendez
Your email (enter to leave blank): rodmen@gmail.com
Reason of lock (enter to leave blank): I made some changes, please keep it       
        Locked deployment to env environment

Finished Magallanes
```

```
[rodmen@localhost Magallanes]$ bin/mage deploy to:env
Starting Magallanes

        This environment is locked!

Locked environment at date: 2014-06-26 14:19:37
Locked by Rodrigo Mendez (rodmen@gmail.com)
I made some changes, please keep it
Finished Magallanes

```
