### PR TITLE
Add system-wide installation to the readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,15 @@ And finally we can use Magallanes from the vendor's bin:
 $ bin/mage version
 ```
 
+### System-wide installation with composer ###
+
+```bash
+$ composer global require "andres-montanez/magallanes=1.0.*"
+```
+
+Make sure you have ~/.composer/vendor/bin/ in your path.
+You can now use Magallanes by using the ````mage```` command.
+
 ### Can you give me some examples/ideas? ###
 **Sure!**
 Suppose you have a checkout of your app and you have to deploy it to four servers;


### PR DESCRIPTION
With this command, you can install mage system-wide, so you only need one install for all your projects.
