### PR TITLE
bugfix, deployment targz

### DIFF
--- a/Mage/Task/BuiltIn/Deployment/Strategy/TarGzTask.php
+++ b/Mage/Task/BuiltIn/Deployment/Strategy/TarGzTask.php
@@ -66,7 +66,7 @@ class TarGzTask extends BaseStrategyTaskAbstract implements IsReleaseAware
             $excludeCmd .= ' --exclude=' . $excludeFile;
         }
 
-        $command = 'tar cfz ' . $localTarGz . '.tar.gz ' . $excludeCmd . ' ' . $this->getConfig()->deployment('from');
+        $command = 'tar cfz ' . $localTarGz . '.tar.gz ' . $excludeCmd . ' -C ' . $this->getConfig()->deployment('from') . ' .';
         $result = $this->runCommandLocal($command);
 
         // Copy Tar Gz  to Remote Host


### PR DESCRIPTION
- the created tar only includes relative from the defined from
- now it is possible to use absolute path in .mage/deployment/*.yaml 
- deployment.from: ./
- deployment.from: /foo/bar/baz
