### PR TITLE
Fix RsyncTask::excludes().

### DIFF
--- a/Mage/Task/BuiltIn/Deployment/Strategy/RsyncTask.php
+++ b/Mage/Task/BuiltIn/Deployment/Strategy/RsyncTask.php
@@ -111,7 +111,7 @@ class RsyncTask extends BaseStrategyTaskAbstract implements IsReleaseAware
     {
         $excludesRsync = '';
         foreach ($excludes as $exclude) {
-            $excludesRsync .= ' --exclude ' . $exclude . ' ';
+            $excludesRsync .= ' --exclude=' . escapeshellarg($exclude) . ' ';
         }
 
         $excludesRsync = trim($excludesRsync);


### PR DESCRIPTION
Added missing "=", also added escapeshellarg (never a bad idea when dealing with folder names and/or wildcards in parameters).
