### PR TITLE
Add composer_cmd as a parameter to composer commands

### DIFF
--- a/Mage/Task/BuiltIn/Composer/ComposerAbstractTask.php
+++ b/Mage/Task/BuiltIn/Composer/ComposerAbstractTask.php
@@ -19,9 +19,9 @@ use Mage\Task\AbstractTask;
  */
 abstract class ComposerAbstractTask extends AbstractTask
 {
-    protected function getComposerPath()
+    protected function getComposerCmd()
     {
-        $composerPath = $this->getParameter('composer_path', 'php composer.phar');
-        return $this->getConfig()->general('composer_path', $composerPath);
+        $composerCmd = $this->getParameter('composer_cmd', 'php composer.phar');
+        return $this->getConfig()->general('composer_cmd', $composerCmd);
     }
 }

--- a/Mage/Task/BuiltIn/Composer/GenerateAutoloadTask.php
+++ b/Mage/Task/BuiltIn/Composer/GenerateAutoloadTask.php
@@ -23,6 +23,6 @@ class GenerateAutoloadTask extends ComposerAbstractTask
      */
     public function run()
     {
-        return $this->runCommand($this->getComposerPath() . ' dumpautoload --optimize');
+        return $this->runCommand($this->getComposerCmd() . ' dumpautoload --optimize');
     }
 }

--- a/Mage/Task/BuiltIn/Composer/InstallTask.php
+++ b/Mage/Task/BuiltIn/Composer/InstallTask.php
@@ -23,6 +23,6 @@ class InstallTask extends ComposerAbstractTask
      */
     public function run()
     {
-        return $this->runCommand($this->getComposerPath() . ' install');
+        return $this->runCommand($this->getComposerCmd() . ' install');
     }
 }


### PR DESCRIPTION
By default `composer/install` executes composer command with `composer.phar` in project path. It's a bit problematic, when composer is installed globally or in custom path. 
This PR includes customizable `composer_cmd`, so calling `composer/install` task is as simple as:

```
tasks:
  pre-deploy:
    - composer/install: {composer_cmd: 'composer'}
```

I've also changed all occurences of `composer_path` to `composer_cmd` because previous `composer_path` was not exactly the path where composer is but the command to call to run `composer`.
Tested and working. Feel free to review!
