### PR TITLE
Add $preCommand option to composer builin task

### DIFF
--- a/Mage/Task/BuiltIn/Composer/InstallTask.php
+++ b/Mage/Task/BuiltIn/Composer/InstallTask.php
@@ -23,7 +23,10 @@ class InstallTask extends ComposerAbstractTask
      */
     public function run()
     {
+        // Options
         $dev = $this->getParameter('dev', true);
-        return $this->runCommand($this->getComposerCmd() . ' install' . ($dev ? ' --dev' : ' --no-dev'));
+        $preCommand = $this->getParameter('preCommand', '');
+
+        return $this->runCommand(' '.$preCommand.' '.$this->getComposerCmd() . ' install' . ($dev ? ' --dev' : ' --no-dev'));
     }
 }


### PR DESCRIPTION
I need to set SYMFONY_ENV to prod, because of
https://github.com/symfony/symfony-standard/issues/662 .
So I add some pre command option.
I use it this way : - composer/install: {preCommand: SYMFONY_ENV=prod}
I let the dev parameter, I base on dev branche.
