### PR TITLE
Improve Composer notes in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,16 +14,16 @@ and run tasks for that freshly deployed code.
 Simply add the following dependency to your project’s composer.json file:
 
 ```js
-    "require": {
+    "require-dev": {
         // ...
-        "andres-montanez/magallanes": "1.0.*"
+        "andres-montanez/magallanes": "~1.0.1"
         // ...
     }
 ```
 Now tell we update the vendors:
 
 ```bash
-$ php composer update
+$ php composer update andres-montanez/magallanes
 ```
 
 And finally we can use Magallanes from the vendor's bin:
@@ -35,7 +35,7 @@ $ bin/mage version
 ### System-wide installation with composer ###
 
 ```bash
-$ composer global require "andres-montanez/magallanes=1.0.*"
+$ composer global require "andres-montanez/magallanes=~1.0.1"
 ```
 
 Make sure you have ~/.composer/vendor/bin/ in your path.


### PR DESCRIPTION
`require-dev` is better than `require` for such tool, because it is not
needed to be installed on production.

`composer update` without specifying vendor libraries as an argument
will try to update all dependencies which may not be desired.

Related to: https://github.com/andres-montanez/MagallanesSite/pull/3
