### PR TITLE
SCM: Git clone performance

### DIFF
--- a/Mage/Task/BuiltIn/Scm/CloneTask.php
+++ b/Mage/Task/BuiltIn/Scm/CloneTask.php
@@ -64,15 +64,11 @@ class CloneTask extends AbstractTask
         $this->runCommandLocal('mkdir -p ' . $this->source['temporal']);
         switch ($this->source['type']) {
             case 'git':
-                // Clone Repo
+                // Fast clone Repo form Branch
                 $command = 'cd ' . $this->source['temporal'] . ' ; '
-                         . 'git clone ' . $this->source['repository'] . ' . ';
+                    . 'git clone --depth 1 -q -b ' . $this->source['from']
+                    . ' ' . $this->source['repository'] . ' . ';
                 $result = $this->runCommandLocal($command);
-
-                // Checkout Branch
-                $command = 'cd ' . $this->source['temporal'] . ' ; '
-                         . 'git checkout ' . $this->source['from'];
-                $result = $result && $this->runCommandLocal($command);
 
                 $this->getConfig()->setFrom($this->source['temporal']);
                 break;


### PR DESCRIPTION
Optimize git clone.

Via:
- http://stackoverflow.com/questions/1778088/how-to-clone-a-single-branch-in-git
- http://stackoverflow.com/questions/6941889/is-git-clone-depth-1-shallow-clone-more-useful-than-it-makes-out
- http://git-scm.com/docs/git-clone
### Test:

Clone https://github.com/phalcon/cphalcon from 1.3.3 branch.
#### 1 Before.

```
$ git clone https://github.com/phalcon/cphalcon.git
Cloning into 'cphalcon'...
remote: Counting objects: 68626, done.
remote: Total 68626 (delta 0), reused 0 (delta 0)
Receiving objects: 100% (68626/68626), 57.36 MiB | 1.55 MiB/s, done.
Resolving deltas: 100% (52217/52217), done.
$ git checkout 1.3.3
```
#### 2. After.

```
$git clone --depth 1 -b 1.3.3 https://github.com/phalcon/cphalcon.git
Cloning into 'cphalcon'...
remote: Counting objects: 8255, done.
remote: Compressing objects: 100% (4588/4588), done.
remote: Total 8255 (delta 5601), reused 5283 (delta 3383)
Receiving objects: 100% (8255/8255), 9.63 MiB | 1.13 MiB/s, done.
Resolving deltas: 100% (5601/5601), done.
```

( -q=Operate quietly. Progress is not reported to the standard error stream.)
#### Reesults: 57.36 MiB vs 9.63 MiB ;)
