### PR TITLE
Throw an error in case when command returns code other than 0

### DIFF
--- a/Mage/Console.php
+++ b/Mage/Console.php
@@ -139,7 +139,7 @@ class Console
                 if (is_int($exitCode) && $exitCode !== 0) {
                     throw new Exception("Command execution failed with following exit code: $exitCode.", $exitCode);
                 } elseif (is_bool($exitCode) && !$exitCode) {
-                    $exitCode = 1000;
+                    $exitCode = 1;
                     throw new Exception("Command execution failed.", $exitCode);
                 }
             } catch (Exception $exception) {


### PR DESCRIPTION
When some of tasks is failing during deployment, whole command should return exit code greater than zero to mark an error.
Related to #130 
