### PR TITLE
Relative linking @ shared file task.

### DIFF
--- a/Mage/Task/BuiltIn/Filesystem/LinkSharedFilesTask.php
+++ b/Mage/Task/BuiltIn/Filesystem/LinkSharedFilesTask.php
@@ -9,7 +9,7 @@ class LinkSharedFilesTask extends AbstractTask implements IsReleaseAware
 {
 
     const LINKED_FOLDERS   = 'linked_folders';
-    const LINKED_STRATEGY  = 'linking_stategy';
+    const LINKED_STRATEGY  = 'linking_strategy';
 
     const ABSOLUTE_LINKING = 'absolute';
     const RELATIVE_LINKING = 'relative';


### PR DESCRIPTION
Most web applications of my clients, I am putting in a chroot environment.
The scheme is as follows:
Nginx + php-fpm with chroot option.

```
[%sitename%]
listen =/var/run/fpmsock.d/%sitename%.sock
listen.owner = example.dev
listen.group = example.dev
listen.mode = 0660

chroot = %vhostspath%%sitename%
```

In this decision, everything is fine, but there is a problem - when
inside chroot to create a symbolic link, it is created relative to chroot.

And inside the chroot environment, it really refers to an existing file
or directory, but outside of the symbolic link leads to nowhere.

In my case it is different directories with static files.

I decide this problem by using relative symbolic links.

```
ln -s ../../../shared/public/images public/images
```

Suggest to introduce the concept - linking_strategy.
"linking_strategy" has two types - absolute and relative

example:

```
tasks:
  pre-deploy:
  on-deploy:
    - filesystem/link-shared-files: { linked_files: [config.php, security.php: absolute],linked_folders: [public/images/goods,public/images/promo,docks], linking_strategy: relative }
  post-release:
  post-deploy:
```

Rebased by upstream/develop
