### PR TITLE
Change runCommandRemote() to runCommand()

### DIFF
--- a/Mage/Task/BuiltIn/Scm/ForceUpdateTask.php
+++ b/Mage/Task/BuiltIn/Scm/ForceUpdateTask.php
@@ -65,13 +65,13 @@ class ForceUpdateTask extends AbstractTask
                 $remote = $this->getParameter('remote', 'origin');
                 
                 $command = 'git fetch ' . $remote . ' ' . $branch;
-                $result = $this->runCommandRemote($command);
+                $result = $this->runCommand($command);
 
                 $command = 'git reset --hard ' . $remote . '/' . $branch;
-                $result = $result && $this->runCommandRemote($command);
+                $result = $result && $this->runCommand($command);
 
                 $command = 'git pull ' . $remote . ' ' . $branch;
-                $result = $result && $this->runCommandRemote($command);
+                $result = $result && $this->runCommand($command);
                 break;
 
             default:
@@ -79,7 +79,6 @@ class ForceUpdateTask extends AbstractTask
                 break;
         }
 
-        $result = $this->runCommandLocal($command);
         $this->getConfig()->reload();
 
         return $result;


### PR DESCRIPTION
Change runCommandRemote() to runCommand(), you decide if the command is running local or remote depending of the stage you put the scm/force-update task on. Remove the last $result = $this->runCommandLocal($command), not necessary.
