### PR TITLE
Fixes #159: PHPUnit tests tuning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 vendor
 mage.phar
+bin
+!bin/mage
 
 # OS generated files # // GitHub Recommendation
 ######################

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,9 @@
             "Command\\": ".mage/commands"
         }
     },
+    "config": {
+        "bin-dir": "bin"
+    },
     "bin": [
         "bin/mage"
     ]

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "a19528b890d301384e45c1ed7d221e26",
+    "hash": "c66ae8cd7e44d614445b273f310d9c34",
     "packages": [],
     "packages-dev": [
         {
@@ -755,6 +755,7 @@
     "minimum-stability": "stable",
     "stability-flags": [],
     "prefer-stable": false,
+    "prefer-lowest": false,
     "platform": {
         "php": ">=5.3"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,8 +5,8 @@
          backupGlobals="false"
          verbose="true"
          strict="true"
-         colors="false">
-    <testsuite name="small">
+         colors="true">
+    <testsuite name="unit-tests">
       <directory suffix="Test.php">tests</directory>
     </testsuite>
 

--- a/tests/MageTest/Console/ColorsTest.php
+++ b/tests/MageTest/Console/ColorsTest.php
@@ -11,6 +11,7 @@ use PHPUnit_Framework_TestCase;
  */
 class ColorsTest extends PHPUnit_Framework_TestCase
 {
+    protected $noColorParameter = "no-color";
     /**
      * @group 159
      * @covers ::color
@@ -20,7 +21,7 @@ class ColorsTest extends PHPUnit_Framework_TestCase
         $config = $this->getMock('Mage\Config');
         $config->expects($this->once())
             ->method('getParameter')
-            ->with('no-color')
+            ->with($this->noColorParameter)
             ->will($this->returnValue(false));
 
         $string = '<green>FooBar</green>';
@@ -41,7 +42,7 @@ class ColorsTest extends PHPUnit_Framework_TestCase
         $config = $this->getMock('Mage\Config');
         $config->expects($this->once())
             ->method('getParameter')
-            ->with('no-color')
+            ->with($this->noColorParameter)
             ->will($this->returnValue(true));
 
         $string = '<black>FooBar</black>';
@@ -62,7 +63,7 @@ class ColorsTest extends PHPUnit_Framework_TestCase
         $config = $this->getMock('Mage\Config');
         $config->expects($this->once())
             ->method('getParameter')
-            ->with('no-color')
+            ->with($this->noColorParameter)
             ->will($this->returnValue(false));
 
         $string = '<foo>FooBar</foo>';

--- a/tests/MageTest/Console/ColorsTest.php
+++ b/tests/MageTest/Console/ColorsTest.php
@@ -7,11 +7,13 @@ use PHPUnit_Framework_TestCase;
 
 /**
  * @group Mage_Console_Colors
+ * @coversDefaultClass Mage\Console\Colors
  */
 class ColorsTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @group 159
+     * @covers ::color
      */
     public function testColor()
     {
@@ -32,6 +34,7 @@ class ColorsTest extends PHPUnit_Framework_TestCase
 
     /**
      * @group 159
+     * @covers ::color
      */
     public function testColorNoColor()
     {
@@ -52,6 +55,7 @@ class ColorsTest extends PHPUnit_Framework_TestCase
 
     /**
      * @group 159
+     * @covers ::color
      */
     public function testColorUnknownColorName()
     {

--- a/tests/MageTest/Console/ColorsTest.php
+++ b/tests/MageTest/Console/ColorsTest.php
@@ -11,7 +11,7 @@ use PHPUnit_Framework_TestCase;
  */
 class ColorsTest extends PHPUnit_Framework_TestCase
 {
-    protected $noColorParameter = "no-color";
+    private $noColorParameter = "no-color";
     /**
      * @group 159
      * @covers ::color

--- a/tests/MageTest/Console/ColorsTest.php
+++ b/tests/MageTest/Console/ColorsTest.php
@@ -18,6 +18,7 @@ class ColorsTest extends PHPUnit_Framework_TestCase
         $config = $this->getMock('Mage\Config');
         $config->expects($this->once())
             ->method('getParameter')
+            ->with('no-color')
             ->will($this->returnValue(false));
 
         $string = '<green>FooBar</green>';
@@ -37,6 +38,7 @@ class ColorsTest extends PHPUnit_Framework_TestCase
         $config = $this->getMock('Mage\Config');
         $config->expects($this->once())
             ->method('getParameter')
+            ->with('no-color')
             ->will($this->returnValue(true));
 
         $string = '<black>FooBar</black>';
@@ -56,6 +58,7 @@ class ColorsTest extends PHPUnit_Framework_TestCase
         $config = $this->getMock('Mage\Config');
         $config->expects($this->once())
             ->method('getParameter')
+            ->with('no-color')
             ->will($this->returnValue(false));
 
         $string = '<foo>FooBar</foo>';


### PR DESCRIPTION
Hey,
As I mentioned in #159 , I've done some fixes and corrections for PHPUnit test environment for Magallanes. I've also noticed and fixed following problems:
* lack of `phpunit` in `bin` directory while doing installing dependencies by composer. I've fixed that by adding `bin-dir` to `composer.json`
* no colors... for phpunit output :) Changed phpunit default configuration in `phpunit.xml.dist`
* coverage - I've added `coversDefaultClass` and `covers` in test class to be sure that those test methods test that what we want to test

Please free to code-review!
@SenseException @andres-montanez 

PS. Sorry, I had to close previous PR, because I accidentally compared it to `master` branch again :(