### PR TITLE
Use instanceof instead of method is_a

### DIFF
--- a/Mage/Task/Factory.php
+++ b/Mage/Task/Factory.php
@@ -59,7 +59,7 @@ class Factory
 
         $instance = new $className($taskConfig, $inRollback, $stage, $taskParameters);
 
-        if (!is_a($instance, 'Mage\Task\AbstractTask')) {
+        if (!($instance instanceof AbstractTask)) {
             throw new Exception('The Task ' . $taskName . ' must be an instance of Mage\Task\AbstractTask.');
         }
 


### PR DESCRIPTION
Since **is_a** is a method, it is significantly slower than using instanceof

Following is a perfomance comparison:
http://micro-optimization.com/is_a-vs-instanceof
