### PR TITLE
fix: DeployCommand does not fail after failed "Deployment Task"

### DIFF
--- a/Mage/Command/BuiltIn/DeployCommand.php
+++ b/Mage/Command/BuiltIn/DeployCommand.php
@@ -202,7 +202,11 @@ class DeployCommand extends AbstractCommand implements RequiresEnvironment
         if (self::$failedTasks === 0) {
             $exitCode = 0;
         }
-
+        
+        if (self::$deployStatus === self::FAILED) {
+            $exitCode = 1;
+        }
+        
         return $exitCode;
     }
 


### PR DESCRIPTION
fix: DeployCommand does not fail when no one "Post-Deployment Tasks" failed and failed "Deployment Task" exist