### PR TITLE
Fix/composer autoload

### DIFF
--- a/bin/mage
+++ b/bin/mage
@@ -16,7 +16,9 @@ $baseDir = dirname(dirname(__FILE__));
 define('MAGALLANES_VERSION', '1.0.3');
 define('MAGALLANES_DIRECTORY', $baseDir);
 
-if (file_exists(__DIR__ . '/../../../autoload.php')) {
+if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
+    require_once __DIR__ . '/../vendor/autoload.php';
+} else if (file_exists(__DIR__ . '/../../../autoload.php')) {
     require_once __DIR__ . '/../../../autoload.php';
 } else {
     require_once $baseDir . '/Mage/Autoload.php';

--- a/bin/mage
+++ b/bin/mage
@@ -16,8 +16,8 @@ $baseDir = dirname(dirname(__FILE__));
 define('MAGALLANES_VERSION', '1.0.3');
 define('MAGALLANES_DIRECTORY', $baseDir);
 
-if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
-    require_once __DIR__ . '/../vendor/autoload.php';
+if (file_exists(__DIR__ . '/../../../autoload.php')) {
+    require_once __DIR__ . '/../../../autoload.php';
 } else {
     require_once $baseDir . '/Mage/Autoload.php';
     $loader = new \Mage\Autoload();

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
     "autoload": {
         "psr-4": {
             "Mage\\": "./Mage",
-            "Task\\": ".mage/tasks",
-            "Command\\": ".mage/commands"
+            "Task\\": "../../../.mage/tasks",
+            "Command\\": "../../../.mage/commands"
         }
     },
     "bin": [

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "andres-montanez/magallanes",
+    "name": "jhuet/magallanes",
     "description": "A Deployment Tool for PHP Applications",
     "homepage": "http://magephp.com",
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
     "autoload": {
         "psr-4": {
             "Mage\\": "./Mage",
-            "Task\\": "../../../.mage/tasks",
-            "Command\\": "../../../.mage/commands"
+            "Task\\": [".mage/tasks", "../../../.mage/tasks"],
+            "Command\\": [".mage/tasks", "../../../.mage/commands"]
         }
     },
     "bin": [

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "jhuet/magallanes",
+    "name": "andres-montanez/magallanes",
     "description": "A Deployment Tool for PHP Applications",
     "homepage": "http://magephp.com",
     "license": "MIT",


### PR DESCRIPTION
@eps90 i'd like your opinion on this because it seems that you added composer autoloading in the ``bin/mage`` and ``composer.json`` files.

On my environment composer autoloader was never called because the ``__DIR__ . '/../vendor/autoload.php'`` path was leading on no file because ``__DIR__`` is referencing this directory : ``vendor/andres-montanez/magallanes/bin``. So i changed it according to that.

Then, because i wasn't using the internal Mage autoloading anymore but Composer's i encountered the same problem for userland ``Task`` and ``Command`` namespaces because the .mage directory is not correctly referenced. Thus i had to change the PSR-4 autoload directories in ``composer.json``

I guess this has never been spotted because everybody's using Mage with another application that is requiring Composer's autoloading file on its side ?