### PR TITLE
fix bug in ApplyFaclsTask due to $cdToDirectoryFirst=true

### DIFF
--- a/Mage/Task/BuiltIn/Filesystem/ApplyFaclsTask.php
+++ b/Mage/Task/BuiltIn/Filesystem/ApplyFaclsTask.php
@@ -25,7 +25,6 @@ class ApplyFaclsTask extends AbstractTask implements IsReleaseAware
     public function run()
     {
         $releasesDirectory = $this->getConfig()->release('directory', 'releases');
-        $releasesDirectory = rtrim($this->getConfig()->deployment('to'), '/') . '/' . $releasesDirectory;
         $currentCopy = $releasesDirectory . '/' . $this->getConfig()->getReleaseId();
 
 


### PR DESCRIPTION
Make `ApplyFaclsTask` compatible with default `AbstractTask::runCommandRemote()` parameter  `$cdToDirectoryFirst=true`.
When a relative path is given in `deployment -> to`, the task will first `cd` into this directory and then also prepend that path to the `setfacl` argument. One of these is enough. (This is true also for absolute paths given in `deployment -> to`, but will not case `setfacl` to fail.)