### PR TITLE
Create release directory for GitRebase strategy

### DIFF
--- a/Mage/Task/BuiltIn/Deployment/Strategy/GitRebaseTask.php
+++ b/Mage/Task/BuiltIn/Deployment/Strategy/GitRebaseTask.php
@@ -34,6 +34,17 @@ class GitRebaseTask extends BaseStrategyTaskAbstract implements IsReleaseAware
      */
     public function run()
     {
+        $this->checkOverrideRelease();
+
+        if ($this->getConfig()->release('enabled', false) == true) {
+            $releasesDirectory = $this->getConfig()->release('directory', 'releases');
+
+            $deployToDirectory = rtrim($this->getConfig()->deployment('to'), '/')
+                . '/' . $releasesDirectory
+                . '/' . $this->getConfig()->getReleaseId();
+            $this->runCommandRemote('mkdir -p ' . $deployToDirectory . '/' . $this->getConfig()->getReleaseId());
+        }
+
         $branch = $this->getParameter('branch', 'master');
         $remote = $this->getParameter('remote', 'origin');
 

--- a/Mage/Task/BuiltIn/Deployment/Strategy/GitRebaseTask.php
+++ b/Mage/Task/BuiltIn/Deployment/Strategy/GitRebaseTask.php
@@ -42,7 +42,7 @@ class GitRebaseTask extends BaseStrategyTaskAbstract implements IsReleaseAware
             $deployToDirectory = rtrim($this->getConfig()->deployment('to'), '/')
                 . '/' . $releasesDirectory
                 . '/' . $this->getConfig()->getReleaseId();
-            $this->runCommandRemote('mkdir -p ' . $deployToDirectory . '/' . $this->getConfig()->getReleaseId());
+            $this->runCommandRemote('mkdir -p ' . $deployToDirectory);
         }
 
         $branch = $this->getParameter('branch', 'master');


### PR DESCRIPTION
I've brought back some piece of code removed in https://github.com/andres-montanez/Magallanes/commit/92b22d52a3603b2b7c8f22b3baadc470ecb3bc36#diff-81da38bff73f46a53c72da138abfb492
GitRebase strategy deployment was failing if relases were enabled because Magallanes was trying to `cd` to directory that didn't exist.