### PR TITLE
Fix 1st deploy bug

### DIFF
--- a/Mage/Task/BuiltIn/Deployment/ReleaseTask.php
+++ b/Mage/Task/BuiltIn/Deployment/ReleaseTask.php
@@ -74,12 +74,13 @@ class ReleaseTask extends AbstractTask implements IsReleaseAware, SkipOnOverride
                 }
             }
 
-            if ($resultFetch && $userGroup != '') {  
-                $command = 'chown -h ' . $userGroup . ' ' . $symlink
-                    . ' && '
-                    . 'chown -R ' . $userGroup . ' ' . $currentCopy
+            if ($resultFetch && $userGroup != '') {
+                $command = 'chown -R ' . $userGroup . ' ' . $currentCopy
                     . ' && '
                     . 'chown ' . $userGroup . ' ' . $releasesDirectory;
+                if (file_exists($symlink)) {
+                    $command.= ' && ' . 'chown -h ' . $userGroup . ' ' . $symlink;
+                }
                 $result = $this->runCommandRemote($command);
                 if (!$result) {
                     return $result;

--- a/Mage/Task/BuiltIn/Deployment/Strategy/RsyncTask.php
+++ b/Mage/Task/BuiltIn/Deployment/Strategy/RsyncTask.php
@@ -73,11 +73,13 @@ class RsyncTask extends BaseStrategyTaskAbstract implements IsReleaseAware
                 // rsync: { copy: yes }
                 $rsync_copy = $this->getConfig()->deployment('rsync');
                 // If copy_tool_rsync, use rsync rather than cp for finer control of what is copied
-                if ($rsync_copy && is_array($rsync_copy) && $rsync_copy['copy'] && isset($rsync_copy['copy_tool_rsync'])) {
-                    $this->runCommandRemote("rsync -a {$this->excludes(array_merge($excludes, $rsync_copy['rsync_excludes']))} "
+                if ($rsync_copy && is_array($rsync_copy) && $rsync_copy['copy'] && is_dir("$releasesDirectory/$currentRelease")) {
+                    if (isset($rsync_copy['copy_tool_rsync'])) {
+                        $this->runCommandRemote("rsync -a {$this->excludes(array_merge($excludes, $rsync_copy['rsync_excludes']))} "
                                           . "$releasesDirectory/$currentRelease/ $releasesDirectory/{$this->getConfig()->getReleaseId()}");
-                } elseif ($rsync_copy && is_array($rsync_copy) && $rsync_copy['copy']) {
-                    $this->runCommandRemote('cp -R ' . $releasesDirectory . '/' . $currentRelease . ' ' . $releasesDirectory . '/' . $this->getConfig()->getReleaseId());
+                    } else {
+                        $this->runCommandRemote('cp -R ' . $releasesDirectory . '/' . $currentRelease . ' ' . $releasesDirectory . '/' . $this->getConfig()->getReleaseId());
+                    }
                 } else {
                     $this->runCommandRemote('mkdir -p ' . $releasesDirectory . '/' . $this->getConfig()->getReleaseId());
                 }


### PR DESCRIPTION
Fix 2 problems leading to a 1st deploy failure (one only with rsync strategy and the other more widely I think)

In `ReleaseTask.php`, we're trying to change owner of symlink file. But on first release the symlink does not exists yet so the release fail (problem comes from #178 I think). I've updated to only check owner if symlink exists. (maybe we can remove totaly the symlink owner check as it's created after ?)

In `RsyncTask.php`, with `rsync_copy` enabled, if the previous release folder does not exists, the release directory is not created, and rsync fail. I've updated to revert to manual empty directory creation if there is no previous release.