### PR TITLE
Add commands tests

### DIFF
--- a/Mage/Command/AbstractCommand.php
+++ b/Mage/Command/AbstractCommand.php
@@ -31,7 +31,7 @@ abstract class AbstractCommand
      * @return integer exit code
      * @throws \Exception
      */
-    public abstract function run();
+    abstract public function run();
 
     /**
      * Sets the Loaded Configuration.

--- a/Mage/Command/BuiltIn/CompileCommand.php
+++ b/Mage/Command/BuiltIn/CompileCommand.php
@@ -22,6 +22,21 @@ use Mage\Compiler;
 class CompileCommand extends AbstractCommand
 {
     /**
+     * @var Compiler
+     */
+    private $compiler;
+
+    public function __construct()
+    {
+        $this->compiler = new Compiler();
+    }
+
+    public function setCompiler(Compiler $compiler)
+    {
+        $this->compiler = $compiler;
+    }
+
+    /**
      * @see \Mage\Compile::compile()
      */
     public function run()

--- a/Mage/Command/BuiltIn/CompileCommand.php
+++ b/Mage/Command/BuiltIn/CompileCommand.php
@@ -42,13 +42,23 @@ class CompileCommand extends AbstractCommand
     public function run()
     {
         if (ini_get('phar.readonly')) {
-            Console::output('The <purple>php.ini</purple> variable <light_red>phar.readonly</light_red> must be <yellow>Off</yellow>.', 1, 2);
+            Console::output(
+                'The <purple>php.ini</purple> variable <light_red>phar.readonly</light_red>'
+                . ' must be <yellow>Off</yellow>.',
+                1,
+                2
+            );
+
             return 200;
         }
 
         $this->compiler->compile();
 
-        Console::output('<light_purple>mage.phar</light_purple> compiled <light_green>successfully</light_green>', 0, 2);
+        Console::output(
+            '<light_purple>mage.phar</light_purple> compiled <light_green>successfully</light_green>',
+            0,
+            2
+        );
 
         return 0;
     }

--- a/Mage/Command/BuiltIn/CompileCommand.php
+++ b/Mage/Command/BuiltIn/CompileCommand.php
@@ -28,7 +28,7 @@ class CompileCommand extends AbstractCommand
 
     public function __construct()
     {
-        $this->compiler = new Compiler();
+        $this->setCompiler(new Compiler());
     }
 
     public function setCompiler(Compiler $compiler)
@@ -46,8 +46,7 @@ class CompileCommand extends AbstractCommand
             return 200;
         }
 
-        $compiler = new Compiler;
-        $compiler->compile();
+        $this->compiler->compile();
 
         Console::output('<light_purple>mage.phar</light_purple> compiled <light_green>successfully</light_green>', 0, 2);
 

--- a/Mage/Command/BuiltIn/CompileCommand.php
+++ b/Mage/Command/BuiltIn/CompileCommand.php
@@ -26,13 +26,12 @@ class CompileCommand extends AbstractCommand
      */
     private $compiler;
 
-    public function __construct()
+    public function __construct(Compiler $compiler = null)
     {
-        $this->setCompiler(new Compiler());
-    }
+        if ($compiler === null) {
+            $compiler = new Compiler();
+        }
 
-    public function setCompiler(Compiler $compiler)
-    {
         $this->compiler = $compiler;
     }
 

--- a/Mage/Command/BuiltIn/ListCommand.php
+++ b/Mage/Command/BuiltIn/ListCommand.php
@@ -40,7 +40,7 @@ class ListCommand extends AbstractCommand
                     $exitCode = $this->listEnvironments();
                     break;
 
-                default;
+                default:
                     throw new Exception('The Type of Elements to List is needed.');
                     break;
             }

--- a/Mage/Command/BuiltIn/LockCommand.php
+++ b/Mage/Command/BuiltIn/LockCommand.php
@@ -35,14 +35,26 @@ class LockCommand extends AbstractCommand implements RequiresEnvironment
         $reason = Console::readInput();
 
         $lockmsg = PHP_EOL;
-        if ($name) $lockmsg .= 'Locked by ' . $name . ' ';
-        if ($email) $lockmsg .= '(' . $email . ')';
-        if ($reason) $lockmsg .= PHP_EOL . $reason . PHP_EOL;
+        if ($name) {
+            $lockmsg .= 'Locked by ' . $name . ' ';
+        }
+        if ($email) {
+            $lockmsg .= '(' . $email . ')';
+        }
+        if ($reason) {
+            $lockmsg .= PHP_EOL . $reason . PHP_EOL;
+        }
 
         $lockFile = getcwd() . '/.mage/' . $this->getConfig()->getEnvironment() . '.lock';
         file_put_contents($lockFile, 'Locked environment at date: ' . date('Y-m-d H:i:s') . $lockmsg);
 
-        Console::output('Locked deployment to <light_purple>' . $this->getConfig()->getEnvironment() . '</light_purple> environment', 1, 2);
+        Console::output(
+            'Locked deployment to <light_purple>'
+            . $this->getConfig()->getEnvironment()
+            . '</light_purple> environment',
+            1,
+            2
+        );
 
         return 0;
     }

--- a/Mage/Command/BuiltIn/UnlockCommand.php
+++ b/Mage/Command/BuiltIn/UnlockCommand.php
@@ -19,8 +19,7 @@ use Mage\Console;
  *
  * @author Andrés Montañez <andres@andresmontanez.com>
  */
-class UnlockCommand
-    extends AbstractCommand implements RequiresEnvironment
+class UnlockCommand extends AbstractCommand implements RequiresEnvironment
 {
     /**
      * Unlocks an Environment
@@ -33,7 +32,12 @@ class UnlockCommand
             @unlink($lockFile);
         }
 
-        Console::output('Unlocked deployment to <light_purple>' . $this->getConfig()->getEnvironment() . '</light_purple> environment', 1, 2);
+        Console::output(
+            'Unlocked deployment to <light_purple>'
+            . $this->getConfig()->getEnvironment() . '</light_purple> environment',
+            1,
+            2
+        );
 
         return 0;
     }

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "4.3.5",
-        "satooshi/php-coveralls": ">=0.6.1"
+        "satooshi/php-coveralls": ">=0.6.1",
+        "malkusch/php-mock": "dev-php-5.3"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         "psr-4": {
             "Mage\\": "./Mage",
             "Task\\": [".mage/tasks", "../../../.mage/tasks"],
-            "Command\\": [".mage/tasks", "../../../.mage/commands"]
+            "Command\\": [".mage/tasks", "../../../.mage/commands"],
+            "MageTest\\": "./tests/MageTest"
         }
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,11 @@
         "psr-4": {
             "Mage\\": "./Mage",
             "Task\\": [".mage/tasks", "../../../.mage/tasks"],
-            "Command\\": [".mage/tasks", "../../../.mage/commands"],
+            "Command\\": [".mage/tasks", "../../../.mage/commands"]
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
             "MageTest\\": "./tests/MageTest"
         }
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "6b9e925b25d502eb4834a26e4ce49e06",
+    "hash": "caa09089c7b57461ed42e97a4449f2c6",
     "packages": [],
     "packages-dev": [
         {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "d82ccc62c52f99a0819bea9b247d4f86",
+    "hash": "6b9e925b25d502eb4834a26e4ce49e06",
     "packages": [],
     "packages-dev": [
         {
@@ -152,6 +152,54 @@
                 "web service"
             ],
             "time": "2014-08-11 04:32:36"
+        },
+        {
+            "name": "malkusch/php-mock",
+            "version": "dev-php-5.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/malkusch/php-mock.git",
+                "reference": "37b301b4b479601232f3919920451c6e777c3264"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/malkusch/php-mock/zipball/37b301b4b479601232f3919920451c6e777c3264",
+                "reference": "37b301b4b479601232f3919920451c6e777c3264",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": ">=4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "malkusch\\phpmock\\": "classes/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "WTFPL-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Markus Malkusch",
+                    "email": "markus@malkusch.de",
+                    "homepage": "http://markus.malkusch.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Mock non deterministic built-in PHP functions (e.g. time() or rand())",
+            "homepage": "https://github.com/malkusch/php-mock",
+            "keywords": [
+                "function",
+                "mock",
+                "stub",
+                "test"
+            ],
+            "time": "2014-12-01 18:01:18"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1208,7 +1256,9 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "malkusch/php-mock": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/tests/MageTest/Command/AbstractCommandTest.php
+++ b/tests/MageTest/Command/AbstractCommandTest.php
@@ -8,6 +8,7 @@ use PHPUnit_Framework_MockObject_MockObject;
 /**
  * Class AbstractCommandTest
  * @package MageTest\Command
+ * @author Jakub Turek <ja@kubaturek.pl>
  * @coversDefaultClass Mage\Command\AbstractCommand
  */
 class AbstractCommandTest extends BaseTest

--- a/tests/MageTest/Command/AbstractCommandTest.php
+++ b/tests/MageTest/Command/AbstractCommandTest.php
@@ -2,6 +2,7 @@
 
 namespace MageTest\Command;
 use Mage\Command\AbstractCommand;
+use MageTest\TestHelper\BaseTest;
 use PHPUnit_Framework_MockObject_MockObject;
 
 /**
@@ -9,7 +10,7 @@ use PHPUnit_Framework_MockObject_MockObject;
  * @package MageTest\Command
  * @coversDefaultClass Mage\Command\AbstractCommand
  */
-class AbstractCommandTest extends \PHPUnit_Framework_TestCase
+class AbstractCommandTest extends BaseTest
 {
     /**
      * @var AbstractCommand|PHPUnit_Framework_MockObject_MockObject
@@ -32,11 +33,8 @@ class AbstractCommandTest extends \PHPUnit_Framework_TestCase
         $configMock = $this->getMock('Mage\Config');
         $this->abstractCommand->setConfig($configMock);
 
-        $configProperty = new \ReflectionProperty($this->abstractCommand, 'config');
-        $configProperty->setAccessible(true);
-        $configValue = $configProperty->getValue($this->abstractCommand);
-
-        $this->assertEquals($configMock, $configValue);
+        $actual = $this->getPropertyValue($this->abstractCommand, 'config');
+        $this->assertEquals($configMock, $actual);
     }
 
     /**
@@ -45,10 +43,7 @@ class AbstractCommandTest extends \PHPUnit_Framework_TestCase
     public function testGetConfig()
     {
         $configMock = $this->getMock('Mage\Config');
-
-        $configProperty = new \ReflectionProperty($this->abstractCommand, 'config');
-        $configProperty->setAccessible(true);
-        $configProperty->setValue($this->abstractCommand, $configMock);
+        $this->setPropertyValue($this->abstractCommand, 'config', $configMock);
 
         $actual = $this->abstractCommand->getConfig();
         $this->assertEquals($configMock, $actual);

--- a/tests/MageTest/Command/AbstractCommandTest.php
+++ b/tests/MageTest/Command/AbstractCommandTest.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace MageTest\Command;
+
 use Mage\Command\AbstractCommand;
 use MageTest\TestHelper\BaseTest;
 use PHPUnit_Framework_MockObject_MockObject;
@@ -35,7 +36,7 @@ class AbstractCommandTest extends BaseTest
         $this->abstractCommand->setConfig($configMock);
 
         $actual = $this->getPropertyValue($this->abstractCommand, 'config');
-        $this->assertEquals($configMock, $actual);
+        $this->assertSame($configMock, $actual);
     }
 
     /**
@@ -47,6 +48,6 @@ class AbstractCommandTest extends BaseTest
         $this->setPropertyValue($this->abstractCommand, 'config', $configMock);
 
         $actual = $this->abstractCommand->getConfig();
-        $this->assertEquals($configMock, $actual);
+        $this->assertSame($configMock, $actual);
     }
 }

--- a/tests/MageTest/Command/AbstractCommandTest.php
+++ b/tests/MageTest/Command/AbstractCommandTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace MageTest\Command;
+use Mage\Command\AbstractCommand;
+use PHPUnit_Framework_MockObject_MockObject;
+
+/**
+ * Class AbstractCommandTest
+ * @package MageTest\Command
+ * @coversDefaultClass Mage\Command\AbstractCommand
+ */
+class AbstractCommandTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var AbstractCommand|PHPUnit_Framework_MockObject_MockObject
+     */
+    private $abstractCommand;
+
+    /**
+     * @before
+     */
+    public function before()
+    {
+        $this->abstractCommand = $this->getMockForAbstractClass('Mage\Command\AbstractCommand');
+    }
+
+    /**
+     * @covers ::setConfig
+     */
+    public function testSetConfig()
+    {
+        $configMock = $this->getMock('Mage\Config');
+        $this->abstractCommand->setConfig($configMock);
+
+        $configProperty = new \ReflectionProperty($this->abstractCommand, 'config');
+        $configProperty->setAccessible(true);
+        $configValue = $configProperty->getValue($this->abstractCommand);
+
+        $this->assertEquals($configMock, $configValue);
+    }
+
+    /**
+     * @covers ::getConfig
+     */
+    public function testGetConfig()
+    {
+        $configMock = $this->getMock('Mage\Config');
+
+        $configProperty = new \ReflectionProperty($this->abstractCommand, 'config');
+        $configProperty->setAccessible(true);
+        $configProperty->setValue($this->abstractCommand, $configMock);
+
+        $actual = $this->abstractCommand->getConfig();
+        $this->assertEquals($configMock, $actual);
+    }
+}

--- a/tests/MageTest/Command/AbstractCommandTest.php
+++ b/tests/MageTest/Command/AbstractCommandTest.php
@@ -33,10 +33,7 @@ class AbstractCommandTest extends BaseTest
     public function testSetConfig()
     {
         $configMock = $this->getMock('Mage\Config');
-        $this->abstractCommand->setConfig($configMock);
-
-        $actual = $this->getPropertyValue($this->abstractCommand, 'config');
-        $this->assertSame($configMock, $actual);
+        $this->doTestSetter($this->abstractCommand, 'config', $configMock);
     }
 
     /**
@@ -45,9 +42,6 @@ class AbstractCommandTest extends BaseTest
     public function testGetConfig()
     {
         $configMock = $this->getMock('Mage\Config');
-        $this->setPropertyValue($this->abstractCommand, 'config', $configMock);
-
-        $actual = $this->abstractCommand->getConfig();
-        $this->assertSame($configMock, $actual);
+        $this->doTestGetter($this->abstractCommand, 'config', $configMock);
     }
 }

--- a/tests/MageTest/Command/BuiltIn/CompileCommandTest.php
+++ b/tests/MageTest/Command/BuiltIn/CompileCommandTest.php
@@ -4,12 +4,20 @@ namespace MageTest\Command\BuiltIn;
 
 use Mage\Command\BuiltIn\CompileCommand;
 use MageTest\TestHelper\BaseTest;
+use malkusch\phpmock\FixedValueFunction;
+use malkusch\phpmock\Mock;
+use malkusch\phpmock\MockBuilder;
 
 /**
  * Class CompileCommandTest
  * @package MageTest\Command\BuiltIn
  * @coversDefaultClass Mage\Command\BuiltIn\CompileCommand
  * @uses Mage\Compiler
+ * @uses malkusch\phpmock\FixedValueFunction
+ * @uses malkusch\phpmock\Mock
+ * @uses malkusch\phpmock\MockBuilder
+ * @uses Mage\Console
+ * @uses Mage\Console\Colors
  */
 class CompileCommandTest extends BaseTest
 {
@@ -19,25 +27,47 @@ class CompileCommandTest extends BaseTest
     private $compileCommand;
 
     /**
+     * @var FixedValueFunction
+     */
+    private $iniGetValue;
+
+    /**
+     * @var Mock
+     */
+    private $iniGetMock;
+
+
+    /**
      * @before
      */
     public function before()
     {
         $this->compileCommand = new CompileCommand();
+
+        $this->iniGetValue = new FixedValueFunction();
+        $mockBuilder = new MockBuilder();
+        $this->iniGetMock = $mockBuilder->setNamespace('Mage\Command\BuiltIn')
+            ->setName("ini_get")
+            ->setCallableProvider($this->iniGetValue)
+            ->build();
+        $this->iniGetMock->disable();
+        $this->iniGetMock->enable();
+
+        $this->setUpConsoleStatics();
     }
 
     /**
      * @covers ::__construct
+     * @covers ::setCompiler
      */
     public function testConstruct()
     {
-        $compileCommand = new CompileCommand();
-
-        $compilerProperty = $this->getPropertyValue($compileCommand, 'compiler');
+        $compilerProperty = $this->getPropertyValue($this->compileCommand, 'compiler');
         $this->assertInstanceOf('Mage\Compiler', $compilerProperty);
     }
 
     /**
+     * @covers ::__construct
      * @covers ::setCompiler
      */
     public function testSetCompiler()
@@ -47,5 +77,44 @@ class CompileCommandTest extends BaseTest
 
         $compilerProperty = $this->getPropertyValue($this->compileCommand, 'compiler');
         $this->assertEquals($compilerMock, $compilerProperty);
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::setCompiler
+     * @covers ::run
+     */
+    public function testRun()
+    {
+        $expectedOutput = "mage.phar compiled successfully\n\n";
+        $expectedExitCode = 0;
+        $this->expectOutputString($expectedOutput);
+
+        $compilerMock = $this->getMock('Mage\Compiler');
+        $compilerMock->expects($this->once())
+            ->method('compile');
+
+        $this->iniGetValue->setValue(false);
+        $this->compileCommand->setCompiler($compilerMock);
+        $actualExitCode = $this->compileCommand->run();
+
+        $this->assertEquals($expectedExitCode, $actualExitCode);
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::setCompiler
+     * @covers ::run
+     */
+    public function testRunWhenPharReadonlyEnabled()
+    {
+        $expectedOutput = "\tThe php.ini variable phar.readonly must be Off.\n\n";
+        $expectedExitCode = 200;
+        $this->expectOutputString($expectedOutput);
+        $this->iniGetValue->setValue(true);
+
+        $actualExitCode = $this->compileCommand->run();
+
+        $this->assertEquals($expectedExitCode, $actualExitCode);
     }
 }

--- a/tests/MageTest/Command/BuiltIn/CompileCommandTest.php
+++ b/tests/MageTest/Command/BuiltIn/CompileCommandTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace MageTest\Command\BuiltIn;
+
+use Mage\Command\BuiltIn\CompileCommand;
+use MageTest\TestHelper\BaseTest;
+
+/**
+ * Class CompileCommandTest
+ * @package MageTest\Command\BuiltIn
+ * @coversDefaultClass Mage\Command\BuiltIn\CompileCommand
+ * @uses Mage\Compiler
+ */
+class CompileCommandTest extends BaseTest
+{
+    /**
+     * @var CompileCommand
+     */
+    private $compileCommand;
+
+    /**
+     * @before
+     */
+    public function before()
+    {
+        $this->compileCommand = new CompileCommand();
+    }
+
+    /**
+     * @covers ::__construct
+     */
+    public function testConstruct()
+    {
+        $compileCommand = new CompileCommand();
+
+        $compilerProperty = $this->getPropertyValue($compileCommand, 'compiler');
+        $this->assertInstanceOf('Mage\Compiler', $compilerProperty);
+    }
+
+    /**
+     * @covers ::setCompiler
+     */
+    public function testSetCompiler()
+    {
+        $compilerMock = $this->getMock('Mage\Compiler');
+        $this->compileCommand->setCompiler($compilerMock);
+
+        $compilerProperty = $this->getPropertyValue($this->compileCommand, 'compiler');
+        $this->assertEquals($compilerMock, $compilerProperty);
+    }
+}

--- a/tests/MageTest/Command/BuiltIn/CompileCommandTest.php
+++ b/tests/MageTest/Command/BuiltIn/CompileCommandTest.php
@@ -46,10 +46,13 @@ class CompileCommandTest extends BaseTest
      */
     public function testConstruct()
     {
-        $compileCommand = $this->getRawCompileCommand();
+        $compilerMock = $this->getMock('Mage\Compiler');
+        $compileCommand = new CompileCommand($compilerMock);
+
         $compilerProperty = $this->getPropertyValue($compileCommand, 'compiler');
 
         $this->assertInstanceOf('Mage\Compiler', $compilerProperty);
+        $this->assertSame($compilerMock, $compilerProperty);
     }
 
     /**
@@ -96,15 +99,10 @@ class CompileCommandTest extends BaseTest
         $this->expectOutputString($expectedOutput);
         $this->iniGetValue->setValue(true);
 
-        $compileCommand = $this->getRawCompileCommand();
+        $compilerMock = $this->getMock('Mage\Compiler');
+        $compileCommand = new CompileCommand($compilerMock);
         $actualExitCode = $compileCommand->run();
 
         $this->assertEquals($expectedExitCode, $actualExitCode);
-    }
-
-    private function getRawCompileCommand()
-    {
-        $compilerMock = $this->getMock('Mage\Compiler');
-        return new CompileCommand($compilerMock);
     }
 }

--- a/tests/MageTest/Command/BuiltIn/CompileCommandTest.php
+++ b/tests/MageTest/Command/BuiltIn/CompileCommandTest.php
@@ -32,12 +32,6 @@ class CompileCommandTest extends BaseTest
     private $iniGetValue;
 
     /**
-     * @var Mock
-     */
-    private $iniGetMock;
-
-
-    /**
      * @before
      */
     public function before()
@@ -46,12 +40,12 @@ class CompileCommandTest extends BaseTest
 
         $this->iniGetValue = new FixedValueFunction();
         $mockBuilder = new MockBuilder();
-        $this->iniGetMock = $mockBuilder->setNamespace('Mage\Command\BuiltIn')
+        $iniGetMock = $mockBuilder->setNamespace('Mage\Command\BuiltIn')
             ->setName("ini_get")
             ->setCallableProvider($this->iniGetValue)
             ->build();
-        $this->iniGetMock->disable();
-        $this->iniGetMock->enable();
+        $iniGetMock->disable();
+        $iniGetMock->enable();
 
         $this->setUpConsoleStatics();
     }

--- a/tests/MageTest/Command/BuiltIn/CompileCommandTest.php
+++ b/tests/MageTest/Command/BuiltIn/CompileCommandTest.php
@@ -5,14 +5,12 @@ namespace MageTest\Command\BuiltIn;
 use Mage\Command\BuiltIn\CompileCommand;
 use MageTest\TestHelper\BaseTest;
 use malkusch\phpmock\FixedValueFunction;
-use malkusch\phpmock\Mock;
 use malkusch\phpmock\MockBuilder;
 
 /**
  * Class CompileCommandTest
  * @package MageTest\Command\BuiltIn
  * @coversDefaultClass Mage\Command\BuiltIn\CompileCommand
- * @uses Mage\Compiler
  * @uses malkusch\phpmock\FixedValueFunction
  * @uses malkusch\phpmock\Mock
  * @uses malkusch\phpmock\MockBuilder
@@ -21,11 +19,6 @@ use malkusch\phpmock\MockBuilder;
  */
 class CompileCommandTest extends BaseTest
 {
-    /**
-     * @var CompileCommand
-     */
-    private $compileCommand;
-
     /**
      * @var FixedValueFunction
      */
@@ -36,8 +29,6 @@ class CompileCommandTest extends BaseTest
      */
     public function before()
     {
-        $this->compileCommand = new CompileCommand();
-
         $this->iniGetValue = new FixedValueFunction();
         $mockBuilder = new MockBuilder();
         $iniGetMock = $mockBuilder->setNamespace('Mage\Command\BuiltIn')
@@ -52,30 +43,28 @@ class CompileCommandTest extends BaseTest
 
     /**
      * @covers ::__construct
-     * @covers ::setCompiler
      */
     public function testConstruct()
     {
-        $compilerProperty = $this->getPropertyValue($this->compileCommand, 'compiler');
+        $compileCommand = $this->getRawCompileCommand();
+        $compilerProperty = $this->getPropertyValue($compileCommand, 'compiler');
+
         $this->assertInstanceOf('Mage\Compiler', $compilerProperty);
     }
 
     /**
      * @covers ::__construct
-     * @covers ::setCompiler
      */
-    public function testSetCompiler()
+    public function testConstructWithNoParams()
     {
-        $compilerMock = $this->getMock('Mage\Compiler');
-        $this->compileCommand->setCompiler($compilerMock);
+        $compileCommand = new CompileCommand();
+        $compilerProperty = $this->getPropertyValue($compileCommand, 'compiler');
 
-        $compilerProperty = $this->getPropertyValue($this->compileCommand, 'compiler');
-        $this->assertEquals($compilerMock, $compilerProperty);
+        $this->assertInstanceOf('Mage\Compiler', $compilerProperty);
     }
 
     /**
      * @covers ::__construct
-     * @covers ::setCompiler
      * @covers ::run
      */
     public function testRun()
@@ -84,20 +73,20 @@ class CompileCommandTest extends BaseTest
         $expectedExitCode = 0;
         $this->expectOutputString($expectedOutput);
 
+        $this->iniGetValue->setValue(false);
+
         $compilerMock = $this->getMock('Mage\Compiler');
         $compilerMock->expects($this->once())
             ->method('compile');
+        $compileCommand = new CompileCommand($compilerMock);
 
-        $this->iniGetValue->setValue(false);
-        $this->compileCommand->setCompiler($compilerMock);
-        $actualExitCode = $this->compileCommand->run();
+        $actualExitCode = $compileCommand->run();
 
         $this->assertEquals($expectedExitCode, $actualExitCode);
     }
 
     /**
      * @covers ::__construct
-     * @covers ::setCompiler
      * @covers ::run
      */
     public function testRunWhenPharReadonlyEnabled()
@@ -107,8 +96,15 @@ class CompileCommandTest extends BaseTest
         $this->expectOutputString($expectedOutput);
         $this->iniGetValue->setValue(true);
 
-        $actualExitCode = $this->compileCommand->run();
+        $compileCommand = $this->getRawCompileCommand();
+        $actualExitCode = $compileCommand->run();
 
         $this->assertEquals($expectedExitCode, $actualExitCode);
+    }
+
+    private function getRawCompileCommand()
+    {
+        $compilerMock = $this->getMock('Mage\Compiler');
+        return new CompileCommand($compilerMock);
     }
 }

--- a/tests/MageTest/Command/BuiltIn/ListCommandTest.php
+++ b/tests/MageTest/Command/BuiltIn/ListCommandTest.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace MageTest\Command\BuiltIn;
+
+use Mage\Command\BuiltIn\ListCommand;
+use MageTest\TestHelper\BaseTest;
+use malkusch\phpmock\FixedValueFunction;
+use malkusch\phpmock\Mock;
+use malkusch\phpmock\MockBuilder;
+
+/**
+ * Class ListCommandTest
+ * @package MageTest\Command\BuiltIn
+ * @coversDefaultClass Mage\Command\BuiltIn\ListCommand
+ * @uses malkusch\phpmock\Mock
+ * @uses malkusch\phpmock\MockBuilder
+ * @uses malkusch\phpmock\FixedValueFunction
+ * @uses Mage\Console\Colors
+ * @uses Mage\Console
+ * @uses Mage\Command\AbstractCommand
+ */
+class ListCommandTest extends BaseTest
+{
+    /**
+     * @var ListCommand
+     */
+    private $listCommand;
+
+    /**
+     * @var Mock
+     */
+    private $scandirMock;
+
+    /**
+     * @var FixedValueFunction
+     */
+    private $scandirValueObj;
+
+    /**
+     * @before
+     */
+    public function before()
+    {
+        $this->listCommand = new ListCommand();
+
+        $this->scandirValueObj = new FixedValueFunction();
+        $mockBuilder = new MockBuilder();
+        $this->scandirMock = $mockBuilder->setNamespace('Mage\Command\BuiltIn')
+            ->setName("scandir")
+            ->setCallableProvider($this->scandirValueObj)
+            ->build();
+        $this->scandirMock->disable();
+        $this->scandirMock->enable();
+    }
+
+    /**
+     * Disable logging to log file and turn off colors
+     *
+     * @before
+     */
+    public function setUpConsoleStatics()
+    {
+        $consoleReflection = new \ReflectionClass('Mage\Console');
+        $logEnableProperty = $consoleReflection->getProperty('logEnabled');
+        $logEnableProperty->setAccessible(true);
+        $logEnableProperty->setValue(false);
+
+        $configMock = $this->getMock('Mage\Config');
+        $configMock->expects($this->atLeastOnce())
+            ->method('getParameter')
+            ->with('no-color')
+            ->willReturn(true);
+
+        $configProperty = $consoleReflection->getProperty('config');
+        $configProperty->setAccessible(true);
+        $configProperty->setValue($configMock);
+    }
+
+    /**
+     * @covers ::run
+     * @covers ::listEnvironments
+     */
+    public function testListEnvironment()
+    {
+        $expectedOutput = <<<OUTPUT
+\tThese are your configured environments:
+\t\t* local
+\t\t* production
+\t\t* rc
+\t\n
+OUTPUT;
+        $this->expectOutputString($expectedOutput);
+
+        $environmentsFiles = [
+            'rc.yml',
+            'production.yml',
+            'local.yml'
+        ];
+
+        $this->scandirValueObj->setValue($environmentsFiles);
+
+        $configMock = $this->getMock('Mage\Config');
+        $configMock->expects($this->once())
+            ->method('getArgument')
+            ->with(1)
+            ->willReturn('environments');
+        $this->listCommand->setConfig($configMock);
+
+        $this->listCommand->run();
+    }
+
+    /**
+     * @covers ::run
+     * @covers ::listEnvironments
+     */
+    public function testListEnvironmentWithNoEnvironments()
+    {
+        $expectedOutput = "\tYou don't have any environment configured.\n\n";
+        $this->expectOutputString($expectedOutput);
+
+        $this->scandirValueObj->setValue([]);
+
+        $configMock = $this->getMock('Mage\Config');
+        $configMock->expects($this->once())
+            ->method('getArgument')
+            ->with(1)
+            ->willReturn('environments');
+        $this->listCommand->setConfig($configMock);
+        $this->listCommand->run();
+    }
+
+    /**
+     * @covers ::run
+     */
+    public function testRunWithInvalidCommand()
+    {
+        $expectedOutput = "\tThe Type of Elements to List is needed.\n\n";
+        $this->expectOutputString($expectedOutput);
+
+        $configMock = $this->getMock('Mage\Config');
+        $configMock->expects($this->once())
+            ->method('getArgument')
+            ->with(1)
+            ->willReturn('abc');
+        $this->listCommand->setConfig($configMock);
+        $this->listCommand->run();
+    }
+}

--- a/tests/MageTest/Command/BuiltIn/ListCommandTest.php
+++ b/tests/MageTest/Command/BuiltIn/ListCommandTest.php
@@ -76,56 +76,56 @@ class ListCommandTest extends BaseTest
         $configProperty->setValue($configMock);
     }
 
-    /**
-     * @covers ::run
-     * @covers ::listEnvironments
-     */
-    public function testListEnvironment()
+    public function listEnvironmentsProvider()
     {
-        $expectedOutput = <<<OUTPUT
-\tThese are your configured environments:
-\t\t* local
-\t\t* production
-\t\t* rc
-\t\n
-OUTPUT;
-        $this->expectOutputString($expectedOutput);
-
-        $environmentsFiles = [
-            'rc.yml',
-            'production.yml',
-            'local.yml'
-        ];
-
-        $this->scandirValueObj->setValue($environmentsFiles);
-
-        $configMock = $this->getMock('Mage\Config');
-        $configMock->expects($this->once())
-            ->method('getArgument')
-            ->with(1)
-            ->willReturn('environments');
-        $this->listCommand->setConfig($configMock);
-
-        $this->listCommand->run();
+        return array(
+            'normal' => array(
+                'environmentFiles' => array(
+                    'rc.yml',
+                    'production.yml',
+                    'local.yml'
+                ),
+                'expectedOutput' => "\tThese are your configured environments:\n"
+                    . "\t\t* local\n"
+                    . "\t\t* production\n"
+                    . "\t\t* rc\n"
+                    . "\t\n"
+            ),
+            'with_missing_yml_files' => array(
+                'environmentFiles' => array(
+                    'rc',
+                    'production.yml'
+                ),
+                'expectedOutput' => "\tThese are your configured environments:\n"
+                    . "\t\t* production\n"
+                    . "\t\n"
+            ),
+            'with_no_yml_configs' => array(
+                'environmentFiles' => array(
+                    'rc.ini',
+                    'production.txt'
+                ),
+                'expectedOutput' => "\tYou don't have any environment configured.\n\n"
+            ),
+            'with_no_configs' => array(
+                'environmentFiles' => array(),
+                'expectedOutput' => "\tYou don't have any environment configured.\n\n"
+            )
+        );
     }
 
     /**
      * @covers ::run
      * @covers ::listEnvironments
+     * @dataProvider listEnvironmentsProvider
      */
-    public function testListEnvironmentWithNoEnvironments()
+    public function testListEnvironment($environmentFiles, $expectedOutput)
     {
-        $expectedOutput = "\tYou don't have any environment configured.\n\n";
         $this->expectOutputString($expectedOutput);
 
-        $this->scandirValueObj->setValue([]);
+        $this->scandirValueObj->setValue($environmentFiles);
+        $this->mockInputArgument('environments');
 
-        $configMock = $this->getMock('Mage\Config');
-        $configMock->expects($this->once())
-            ->method('getArgument')
-            ->with(1)
-            ->willReturn('environments');
-        $this->listCommand->setConfig($configMock);
         $this->listCommand->run();
     }
 
@@ -137,12 +137,19 @@ OUTPUT;
         $expectedOutput = "\tThe Type of Elements to List is needed.\n\n";
         $this->expectOutputString($expectedOutput);
 
+        $this->mockInputArgument('abc');
+
+        $this->listCommand->run();
+    }
+
+    private function mockInputArgument($argumentValue)
+    {
         $configMock = $this->getMock('Mage\Config');
         $configMock->expects($this->once())
             ->method('getArgument')
             ->with(1)
-            ->willReturn('abc');
+            ->willReturn($argumentValue);
+
         $this->listCommand->setConfig($configMock);
-        $this->listCommand->run();
     }
 }

--- a/tests/MageTest/Command/BuiltIn/ListCommandTest.php
+++ b/tests/MageTest/Command/BuiltIn/ListCommandTest.php
@@ -51,29 +51,8 @@ class ListCommandTest extends BaseTest
             ->build();
         $this->scandirMock->disable();
         $this->scandirMock->enable();
-    }
 
-    /**
-     * Disable logging to log file and turn off colors
-     *
-     * @before
-     */
-    public function setUpConsoleStatics()
-    {
-        $consoleReflection = new \ReflectionClass('Mage\Console');
-        $logEnableProperty = $consoleReflection->getProperty('logEnabled');
-        $logEnableProperty->setAccessible(true);
-        $logEnableProperty->setValue(false);
-
-        $configMock = $this->getMock('Mage\Config');
-        $configMock->expects($this->atLeastOnce())
-            ->method('getParameter')
-            ->with('no-color')
-            ->willReturn(true);
-
-        $configProperty = $consoleReflection->getProperty('config');
-        $configProperty->setAccessible(true);
-        $configProperty->setValue($configMock);
+        $this->setUpConsoleStatics();
     }
 
     public function listEnvironmentsProvider()

--- a/tests/MageTest/Command/BuiltIn/ListCommandTest.php
+++ b/tests/MageTest/Command/BuiltIn/ListCommandTest.php
@@ -89,7 +89,8 @@ class ListCommandTest extends BaseTest
                     . "\t\t* local\n"
                     . "\t\t* production\n"
                     . "\t\t* rc\n"
-                    . "\t\n"
+                    . "\t\n",
+                'expectedExitCode' => 0
             ),
             'with_missing_yml_files' => array(
                 'environmentFiles' => array(
@@ -98,18 +99,21 @@ class ListCommandTest extends BaseTest
                 ),
                 'expectedOutput' => "\tThese are your configured environments:\n"
                     . "\t\t* production\n"
-                    . "\t\n"
+                    . "\t\n",
+                'expectedExitCode' => 0
             ),
             'with_no_yml_configs' => array(
                 'environmentFiles' => array(
                     'rc.ini',
                     'production.txt'
                 ),
-                'expectedOutput' => "\tYou don't have any environment configured.\n\n"
+                'expectedOutput' => "\tYou don't have any environment configured.\n\n",
+                'expectedExitCode' => 220
             ),
             'with_no_configs' => array(
                 'environmentFiles' => array(),
-                'expectedOutput' => "\tYou don't have any environment configured.\n\n"
+                'expectedOutput' => "\tYou don't have any environment configured.\n\n",
+                'expectedExitCode' => 220
             )
         );
     }
@@ -119,14 +123,15 @@ class ListCommandTest extends BaseTest
      * @covers ::listEnvironments
      * @dataProvider listEnvironmentsProvider
      */
-    public function testListEnvironment($environmentFiles, $expectedOutput)
+    public function testListEnvironment($environmentFiles, $expectedOutput, $expectedExitCode)
     {
         $this->expectOutputString($expectedOutput);
 
         $this->scandirValueObj->setValue($environmentFiles);
         $this->mockInputArgument('environments');
 
-        $this->listCommand->run();
+        $actualExitCode = $this->listCommand->run();
+        $this->assertEquals($expectedExitCode, $actualExitCode);
     }
 
     /**
@@ -139,7 +144,9 @@ class ListCommandTest extends BaseTest
 
         $this->mockInputArgument('abc');
 
-        $this->listCommand->run();
+        $expectedExitCode = 221;
+        $actualExitCode = $this->listCommand->run();
+        $this->assertEquals($expectedExitCode, $actualExitCode);
     }
 
     private function mockInputArgument($argumentValue)

--- a/tests/MageTest/Command/BuiltIn/ListCommandTest.php
+++ b/tests/MageTest/Command/BuiltIn/ListCommandTest.php
@@ -27,11 +27,6 @@ class ListCommandTest extends BaseTest
     private $listCommand;
 
     /**
-     * @var Mock
-     */
-    private $scandirMock;
-
-    /**
      * @var FixedValueFunction
      */
     private $scandirValueObj;
@@ -45,12 +40,12 @@ class ListCommandTest extends BaseTest
 
         $this->scandirValueObj = new FixedValueFunction();
         $mockBuilder = new MockBuilder();
-        $this->scandirMock = $mockBuilder->setNamespace('Mage\Command\BuiltIn')
+        $scandirMock = $mockBuilder->setNamespace('Mage\Command\BuiltIn')
             ->setName("scandir")
             ->setCallableProvider($this->scandirValueObj)
             ->build();
-        $this->scandirMock->disable();
-        $this->scandirMock->enable();
+        $scandirMock->disable();
+        $scandirMock->enable();
 
         $this->setUpConsoleStatics();
     }
@@ -128,6 +123,11 @@ class ListCommandTest extends BaseTest
         $this->assertEquals($expectedExitCode, $actualExitCode);
     }
 
+    /**
+     * Stub Config::getArgument to return desired value
+     *
+     * @param String $argumentValue Input argument
+     */
     private function mockInputArgument($argumentValue)
     {
         $configMock = $this->getMock('Mage\Config');

--- a/tests/MageTest/Command/BuiltIn/LockCommandTest.php
+++ b/tests/MageTest/Command/BuiltIn/LockCommandTest.php
@@ -43,6 +43,12 @@ class LockCommandTest extends BaseTest
     public function before()
     {
         self::$fgetsCount = 0;
+        self::$mockName = '';
+        self::$mockEmail = '';
+        self::$mockDesc = '';
+        self::$filePutContentsResult = '';
+        self::$filePutContentsFile = '';
+
         $this->lockCommand = new LockCommand();
 
         $mockBuilder = new MockBuilder();

--- a/tests/MageTest/Command/BuiltIn/LockCommandTest.php
+++ b/tests/MageTest/Command/BuiltIn/LockCommandTest.php
@@ -1,0 +1,199 @@
+<?php
+
+namespace MageTest\Command\BuiltIn;
+
+use Mage\Command\BuiltIn\LockCommand;
+use MageTest\TestHelper\BaseTest;
+use malkusch\phpmock\FixedValueFunction;
+use malkusch\phpmock\MockBuilder;
+
+/**
+ * Class LockCommandTest
+ * @package MageTest\Command\BuiltIn
+ * @coversDefaultClass Mage\Command\BuiltIn\LockCommand
+ * @uses malkusch\phpmock\MockBuilder
+ * @uses malkusch\phpmock\FixedValueFunction
+ * @uses malkusch\phpmock\Mock
+ * @uses Mage\Console\Colors
+ * @uses Mage\Console
+ * @uses Mage\Command\AbstractCommand
+ */
+class LockCommandTest extends BaseTest
+{
+    public static $fgetsCount;
+    public static $mockName;
+    public static $mockEmail;
+    public static $mockDesc;
+    public static $filePutContentsResult;
+    public static $filePutContentsFile;
+
+    /**
+     * @var LockCommand
+     */
+    private $lockCommand;
+
+    /**
+     * @var FixedValueFunction
+     */
+    private $fgetsValue;
+
+    /**
+     * @before
+     */
+    public function before()
+    {
+        self::$fgetsCount = 0;
+        $this->lockCommand = new LockCommand();
+
+        $mockBuilder = new MockBuilder();
+        $fopenMock = $mockBuilder
+            ->setName('fopen')
+            ->setNamespace('Mage')
+            ->setFunction(function () {
+                return 'a';
+            })
+            ->build();
+
+        $this->fgetsValue = new FixedValueFunction();
+        $fgetsMock = $mockBuilder
+            ->setNamespace('Mage')
+            ->setName('fgets')
+            ->setFunction(
+                function () {
+                    switch (LockCommandTest::$fgetsCount) {
+                        case 0:
+                            LockCommandTest::$fgetsCount++;
+                            return LockCommandTest::$mockName;
+                        case 1:
+                            LockCommandTest::$fgetsCount++;
+                            return LockCommandTest::$mockEmail;
+                        case 2:
+                            LockCommandTest::$fgetsCount++;
+                            return LockCommandTest::$mockDesc;
+                        default:
+                            throw new \Exception('"fgets" count limit exceed');
+                    }
+                }
+            )
+            ->build();
+        $getCwdMock = $mockBuilder
+            ->setNamespace('Mage\Command\Builtin')
+            ->setName('getcwd')
+            ->setFunction(
+                function () {
+                    return '';
+                }
+            )
+            ->build();
+        $fileGetContentsMock = $mockBuilder
+            ->setNamespace('Mage\Command\Builtin')
+            ->setName('file_put_contents')
+            ->setFunction(
+                function ($file, $contents) {
+                    LockCommandTest::$filePutContentsFile = $file;
+                    LockCommandTest::$filePutContentsResult = $contents;
+                }
+            )
+            ->build();
+
+        $dateMock = $mockBuilder
+            ->setNamespace('Mage\Command\BuiltIn')
+            ->setName('date')
+            ->setFunction(
+                function () {
+                    return '2015-01-01 12:00:00';
+                }
+            )
+            ->build();
+
+        $fopenMock->disable();
+        $fgetsMock->disable();
+        $getCwdMock->disable();
+        $fileGetContentsMock->disable();
+        $dateMock->disable();
+
+        $fopenMock->enable();
+        $fgetsMock->enable();
+        $getCwdMock->enable();
+        $fileGetContentsMock->enable();
+        $dateMock->enable();
+
+        $this->setUpConsoleStatics();
+    }
+
+    public function lockCommandProvider()
+    {
+        return array(
+            'normal' => array(
+                'name' => 'John Smith',
+                'email' => 'john.smith@example.com',
+                'description' => "There's a critical bug here!",
+                'expectedLockFileContents' => "Locked environment at date: 2015-01-01 12:00:00\n"
+                    . "Locked by John Smith (john.smith@example.com)\n"
+                    . "There's a critical bug here!\n",
+            ),
+            'with_no_name' => array(
+                'name' => '',
+                'email' => 'john.smith@example.com',
+                'description' => "There's a critical bug here!",
+                'expectedLockFileContents' => "Locked environment at date: 2015-01-01 12:00:00\n"
+                    . "(john.smith@example.com)\n"
+                    . "There's a critical bug here!\n",
+            ),
+            'with_no_email' => array(
+                'name' => 'John Smith',
+                'email' => '',
+                'description' => "There's a critical bug here!",
+                'expectedLockFileContents' => "Locked environment at date: 2015-01-01 12:00:00\n"
+                    . "Locked by John Smith \n"
+                    . "There's a critical bug here!\n",
+            ),
+            'with_no_name_nor_email' => array(
+                'name' => '',
+                'email' => '',
+                'description' => "There's a critical bug here!",
+                'expectedLockFileContents' => "Locked environment at date: 2015-01-01 12:00:00\n"
+                    . "\n"
+                    . "There's a critical bug here!\n",
+            ),
+            'with_no_desciption' => array(
+                'name' => 'John Smith',
+                'email' => 'john.smith@example.com',
+                'description' => '',
+                'expectedLockFileContents' => "Locked environment at date: 2015-01-01 12:00:00\n"
+                    . "Locked by John Smith (john.smith@example.com)"
+            ),
+        );
+    }
+
+    /**
+     * @covers ::run
+     * @dataProvider lockCommandProvider
+     */
+    public function testRun($name, $email, $description, $expectedLockFileContents)
+    {
+        $expectedOutput = "Your name (enter to leave blank): "
+            . "Your email (enter to leave blank): "
+            . "Reason of lock (enter to leave blank): "
+            . "\tLocked deployment to production environment\n\n";
+        $this->expectOutputString($expectedOutput);
+        $expectedLockFilePath = '/.mage/production.lock';
+        $expectedExitCode = 0;
+
+        self::$mockName = $name;
+        self::$mockEmail = $email;
+        self::$mockDesc = $description;
+
+        $configMock = $this->getMock('Mage\Config');
+        $configMock->expects($this->atLeastOnce())
+            ->method('getEnvironment')
+            ->willReturn('production');
+        $this->lockCommand->setConfig($configMock);
+
+        $actualExitCode = $this->lockCommand->run();
+
+        $this->assertEquals($expectedExitCode, $actualExitCode);
+        $this->assertEquals($expectedLockFileContents, self::$filePutContentsResult);
+        $this->assertEquals($expectedLockFilePath, self::$filePutContentsFile);
+    }
+}

--- a/tests/MageTest/Command/BuiltIn/UnlockCommandTest.php
+++ b/tests/MageTest/Command/BuiltIn/UnlockCommandTest.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace MageTest\Command\BuiltIn;
+
+use Mage\Command\BuiltIn\UnlockCommand;
+use MageTest\TestHelper\BaseTest;
+use malkusch\phpmock\MockBuilder;
+
+/**
+ * Class UnlockCommandTest
+ * @package MageTest\Command\BuiltIn
+ * @coversDefaultClass Mage\Command\BuiltIn\UnlockCommand
+ * @uses malkusch\phpmock\MockBuilder
+ * @uses malkusch\phpmock\Mock
+ * @uses Mage\Command\AbstractCommand
+ * @uses Mage\Console
+ * @uses Mage\Console\Colors
+ */
+class UnlockCommandTest extends BaseTest
+{
+    /**
+     * @var UnlockCommand
+     */
+    private $unlockCommand;
+
+    public static $isUnlinkCalled;
+    public static $fileExistsResult;
+    public static $isFileExists;
+
+    /**
+     * @before
+     */
+    public function before()
+    {
+        $this->unlockCommand = new UnlockCommand();
+
+        self::$isUnlinkCalled = false;
+        self::$fileExistsResult = false;
+        self::$isFileExists = false;
+
+        $mockBuilder = new MockBuilder();
+        $fileExistsMock = $mockBuilder
+            ->setName('file_exists')
+            ->setNamespace('Mage\Command\BuiltIn')
+            ->setFunction(
+                function ($filePath) {
+                    UnlockCommandTest::$fileExistsResult = $filePath;
+                    return UnlockCommandTest::$isFileExists;
+                }
+            )
+            ->build();
+        $unlinkMock = $mockBuilder
+            ->setName('unlink')
+            ->setNamespace('Mage\Command\BuiltIn')
+            ->setFunction(
+                function () {
+                    UnlockCommandTest::$isUnlinkCalled = true;
+                }
+            )
+            ->build();
+        $getCwdMock = $mockBuilder
+            ->setNamespace('Mage\Command\BuiltIn')
+            ->setName('getcwd')
+            ->setFunction(
+                function () {
+                    return '';
+                }
+            )
+            ->build();
+
+        $fileExistsMock->disable();
+        $unlinkMock->disable();
+        $getCwdMock->disable();
+
+
+        $fileExistsMock->enable();
+        $unlinkMock->enable();
+        $getCwdMock->enable();
+
+        $configMock = $this->getMock('Mage\Config');
+        $configMock->expects($this->atLeastOnce())
+            ->method('getEnvironment')
+            ->willReturn('production');
+        $this->unlockCommand->setConfig($configMock);
+
+        $this->setUpConsoleStatics();
+    }
+
+    /**
+     * @covers ::run
+     */
+    public function testRun()
+    {
+        $expectedOutput = "\tUnlocked deployment to production environment\n\n";
+        $this->expectOutputString($expectedOutput);
+        $expectedLockFilePath = '/.mage/production.lock';
+
+        self::$isFileExists = true;
+
+        $actualExitCode = $this->unlockCommand->run();
+        $expectedExitCode = 0;
+
+        $this->assertTrue(self::$isUnlinkCalled);
+        $this->assertEquals($expectedExitCode, $actualExitCode);
+        $this->assertEquals($expectedLockFilePath, self::$fileExistsResult);
+    }
+
+    /**
+     * @covers ::run
+     */
+    public function testRunIfFileNotExist()
+    {
+        $expectedOutput = "\tUnlocked deployment to production environment\n\n";
+        $this->expectOutputString($expectedOutput);
+        $expectedLockFilePath = '/.mage/production.lock';
+
+        self::$isFileExists = false;
+
+        $actualExitCode = $this->unlockCommand->run();
+        $expectedExitCode = 0;
+
+        $this->assertFalse(self::$isUnlinkCalled);
+        $this->assertEquals($expectedExitCode, $actualExitCode);
+        $this->assertEquals($expectedLockFilePath, self::$fileExistsResult);
+    }
+}

--- a/tests/MageTest/Command/BuiltIn/UnlockCommandTest.php
+++ b/tests/MageTest/Command/BuiltIn/UnlockCommandTest.php
@@ -27,6 +27,18 @@ class UnlockCommandTest extends BaseTest
     public static $fileExistsResult;
     public static $isFileExists;
 
+    public function runProvider()
+    {
+        return array(
+            'happy_path' => array(
+                'file_exists' => true,
+            ),
+            'file_not_exists' => array(
+                'file_exsits' => false
+            )
+        );
+    }
+
     /**
      * @before
      */
@@ -87,38 +99,20 @@ class UnlockCommandTest extends BaseTest
 
     /**
      * @covers ::run
+     * @dataProvider runProvider
      */
-    public function testRun()
+    public function testRun($fileExists)
     {
         $expectedOutput = "\tUnlocked deployment to production environment\n\n";
         $this->expectOutputString($expectedOutput);
         $expectedLockFilePath = '/.mage/production.lock';
 
-        self::$isFileExists = true;
+        self::$isFileExists = $fileExists;
 
         $actualExitCode = $this->unlockCommand->run();
         $expectedExitCode = 0;
 
-        $this->assertTrue(self::$isUnlinkCalled);
-        $this->assertEquals($expectedExitCode, $actualExitCode);
-        $this->assertEquals($expectedLockFilePath, self::$fileExistsResult);
-    }
-
-    /**
-     * @covers ::run
-     */
-    public function testRunIfFileNotExist()
-    {
-        $expectedOutput = "\tUnlocked deployment to production environment\n\n";
-        $this->expectOutputString($expectedOutput);
-        $expectedLockFilePath = '/.mage/production.lock';
-
-        self::$isFileExists = false;
-
-        $actualExitCode = $this->unlockCommand->run();
-        $expectedExitCode = 0;
-
-        $this->assertFalse(self::$isUnlinkCalled);
+        $this->assertEquals(self::$isUnlinkCalled, $fileExists);
         $this->assertEquals($expectedExitCode, $actualExitCode);
         $this->assertEquals($expectedLockFilePath, self::$fileExistsResult);
     }

--- a/tests/MageTest/Command/BuiltIn/UnlockCommandTest.php
+++ b/tests/MageTest/Command/BuiltIn/UnlockCommandTest.php
@@ -72,7 +72,6 @@ class UnlockCommandTest extends BaseTest
         $unlinkMock->disable();
         $getCwdMock->disable();
 
-
         $fileExistsMock->enable();
         $unlinkMock->enable();
         $getCwdMock->enable();

--- a/tests/MageTest/TestHelper/BaseTest.php
+++ b/tests/MageTest/TestHelper/BaseTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace MageTest\TestHelper;
+
+/**
+ * Class BaseTest
+ * @package MageTest\TestHelper
+ * @author Jakub Turek <ja@kubaturek.pl>
+ */
+abstract class BaseTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Returns value of non-public property from given class
+     *
+     * @param string|object $object Object instance or class name
+     * @param string $propertyName Class' or object's property name
+     * @return mixed
+     */
+    final protected function getPropertyValue($object, $propertyName)
+    {
+        $configProperty = new \ReflectionProperty($object, $propertyName);
+        $configProperty->setAccessible(true);
+
+        return  $configProperty->getValue($object);
+    }
+
+    /**
+     * Sets value to given property and given object
+     *
+     * @param object $object Object instance
+     * @param string $propertyName Property name
+     * @param mixed $value Value to set
+     */
+    final protected function setPropertyValue($object, $propertyName, $value)
+    {
+        $configProperty = new \ReflectionProperty($object, $propertyName);
+        $configProperty->setAccessible(true);
+        $configProperty->setValue($object, $value);
+    }
+}

--- a/tests/MageTest/TestHelper/BaseTest.php
+++ b/tests/MageTest/TestHelper/BaseTest.php
@@ -65,4 +65,59 @@ abstract class BaseTest extends \PHPUnit_Framework_TestCase
         $configProperty->setAccessible(true);
         $configProperty->setValue($configMock);
     }
+
+    /**
+     * Tests getter of given object for given property name and example value
+     *
+     * @param object $object Object instance
+     * @param string $propertyName Property name
+     * @param mixed $propertyValue Value to set
+     */
+    final protected function doTestGetter($object, $propertyName, $propertyValue)
+    {
+        $this->setPropertyValue($object, $propertyName, $propertyValue);
+        $getterName = $this->getGetterName($propertyName);
+
+        $actual = $object->$getterName();
+
+        $this->assertSame($propertyValue, $actual);
+    }
+
+    /**
+     * Tests setter of given object for given property name and example value
+     *
+     * @param object $object Object instance
+     * @param string $propertyName Property name
+     * @param mixed $propertyValue Value to set
+     */
+    final protected function doTestSetter($object, $propertyName, $propertyValue)
+    {
+        $setterName = $this->getSetterName($propertyName);
+        $object->$setterName($propertyValue);
+
+        $actual = $this->getPropertyValue($object, $propertyName);
+        $this->assertSame($propertyValue, $actual);
+    }
+
+    /**
+     * Returns the conventional getter name for given property name
+     *
+     * @param string $propertyName Property name
+     * @return string Getter method name
+     */
+    final protected function getGetterName($propertyName)
+    {
+        return 'get' . ucfirst($propertyName);
+    }
+
+    /**
+     * Returns the conventional setter name for given property name
+     *
+     * @param string $propertyName Property name
+     * @return string Getter method name
+     */
+    final protected function getSetterName($propertyName)
+    {
+        return 'set' . ucfirst($propertyName);
+    }
 }

--- a/tests/MageTest/TestHelper/BaseTest.php
+++ b/tests/MageTest/TestHelper/BaseTest.php
@@ -4,6 +4,11 @@ namespace MageTest\TestHelper;
 
 /**
  * Class BaseTest
+ *
+ * Class containing common methods useful for unit testing.
+ * Since Magallanes keeps compatibility with PHP 5.3, those methods can't be moved to a trait.
+ * This class extends \PHPUnit_Framework_TestCase so it can be used with any test class.
+ *
  * @package MageTest\TestHelper
  * @author Jakub Turek <ja@kubaturek.pl>
  */

--- a/tests/MageTest/TestHelper/BaseTest.php
+++ b/tests/MageTest/TestHelper/BaseTest.php
@@ -105,7 +105,7 @@ abstract class BaseTest extends \PHPUnit_Framework_TestCase
      * @param string $propertyName Property name
      * @return string Getter method name
      */
-    final protected function getGetterName($propertyName)
+    private function getGetterName($propertyName)
     {
         return 'get' . ucfirst($propertyName);
     }
@@ -116,7 +116,7 @@ abstract class BaseTest extends \PHPUnit_Framework_TestCase
      * @param string $propertyName Property name
      * @return string Getter method name
      */
-    final protected function getSetterName($propertyName)
+    private function getSetterName($propertyName)
     {
         return 'set' . ucfirst($propertyName);
     }

--- a/tests/MageTest/TestHelper/BaseTest.php
+++ b/tests/MageTest/TestHelper/BaseTest.php
@@ -42,4 +42,27 @@ abstract class BaseTest extends \PHPUnit_Framework_TestCase
         $configProperty->setAccessible(true);
         $configProperty->setValue($object, $value);
     }
+
+    /**
+     * Disable logging to log file and turn off colors
+     *
+     * @before
+     */
+    protected function setUpConsoleStatics()
+    {
+        $consoleReflection = new \ReflectionClass('Mage\Console');
+        $logEnableProperty = $consoleReflection->getProperty('logEnabled');
+        $logEnableProperty->setAccessible(true);
+        $logEnableProperty->setValue(false);
+
+        $configMock = $this->getMock('Mage\Config');
+        $configMock->expects($this->any())
+            ->method('getParameter')
+            ->with('no-color')
+            ->willReturn(true);
+
+        $configProperty = $consoleReflection->getProperty('config');
+        $configProperty->setAccessible(true);
+        $configProperty->setValue($configMock);
+    }
 }


### PR DESCRIPTION
Hey there!
This PR introduces tests of few commands including:
* `AbstractCommand`
* `CompileCommand`
* `ListCommand`
* `LockCommand`
* `UnlockCommand`

These tests cover the code in 100% (line coverage) without changing current functionality.
Few words about PR:
* I used [malkusch\php-mock](https://github.com/malkusch/php-mock) for creating mocks of PHP's built-in functions. As far as I know, it uses the fact that PHP interpreter will use the function with the same name from the namespace where it was used in. This library contains some other cool options like making **stubs** on built-in functions but since we're keeping compatibility with PHP 5.3, we can't use them and we can just mock them to avoid unexpected results. Fortunatelly, author created the `php-5.3` branch.
* I had to use `@uses` annotation to point that we use some other classes (like statics, impossible to inject and then mock) and not cover them. Without that annotation PHPUnit run with `--coverage-*` trigger will mark all tests as risky. **Note:** I didn't use this annotation only to suppress warnings. Each test class was tested without them to see if there are no other classes under control. As you can see, each test class contains almost the same `@uses` annotations.
* I had to add setter in `CompileCommand` to mock `Mage\Compiler` class. This setter is called in (also created by me) constructor, so nothing changed in this class' functionality.

For now coverage of the project is **22.36%**. Before creating these tests, it was about 7%.
Feel free to review and discuss! Thanks!