### PR TITLE
Add UserKnownHostsFile and StrictHostKeyChecking options to scp command

### DIFF
--- a/Mage/Task/BuiltIn/Deployment/Strategy/TarGzTask.php
+++ b/Mage/Task/BuiltIn/Deployment/Strategy/TarGzTask.php
@@ -92,8 +92,12 @@ class TarGzTask extends BaseStrategyTaskAbstract implements IsReleaseAware
         }
 
         // Copy Tar Gz  to Remote Host
-        $command = 'scp ' . $strategyFlags . ' ' . $this->getConfig()->getHostIdentityFileOption() . $this->getConfig()->getConnectTimeoutOption() . '-P ' . $this->getConfig()->getHostPort() . ' ' . $localTarGz . '.tar.gz '
-                 . $this->getConfig()->deployment('user') . '@' . $this->getConfig()->getHostName() . ':' . $deployToDirectory;
+        $command = 'scp ' . $strategyFlags . ' ' . $this->getConfig()->getHostIdentityFileOption()
+            . $this->getConfig()->getConnectTimeoutOption() . '-P ' . $this->getConfig()->getHostPort()
+            . " -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no "
+            . ' ' . $localTarGz . '.tar.gz '
+            . $this->getConfig()->deployment('user') . '@' . $this->getConfig()->getHostName() . ':'
+            . $deployToDirectory;
         $result = $this->runCommandLocal($command) && $result;
 
         // Strategy Flags


### PR DESCRIPTION
This pull requests fixed #202 issue.
Remove inconsistency between `ssh` and `scp` commands. As @kaiwa noticed, `UserKnownHostsFile` and `StrictHostKeyChecking` ssh options were not set when running `scp` command, what may cause problems when running them.
**To be done**: Let `UserKnownHostsFile` and `StrictHostKeyChecking` options be configurable (#105)