### PR TITLE
don’t fail the initial deployment to a target, and allow ssh without a username

### DIFF
--- a/Mage/Task/AbstractTask.php
+++ b/Mage/Task/AbstractTask.php
@@ -202,7 +202,8 @@ abstract class AbstractTask
         $localCommand = 'ssh ' . $this->getConfig()->getHostIdentityFileOption() . $needs_tty . ' -p ' . $this->getConfig()->getHostPort() . ' '
             . '-q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no '
             . $this->getConfig()->getConnectTimeoutOption()
-            . $this->getConfig()->deployment('user') . '@' . $this->getConfig()->getHostName();
+            . ( $this->getConfig()->deployment('user') != '' ? $this->getConfig()->deployment('user') . '@' : '' )
+            . $this->getConfig()->getHostName();
 
         $remoteCommand = str_replace('"', '\"', $command);
         if ($cdToDirectoryFirst) {

--- a/Mage/Task/BuiltIn/Deployment/ReleaseTask.php
+++ b/Mage/Task/BuiltIn/Deployment/ReleaseTask.php
@@ -78,18 +78,19 @@ class ReleaseTask extends AbstractTask implements IsReleaseAware, SkipOnOverride
                 $command = 'chown -R ' . $userGroup . ' ' . $currentCopy
                     . ' && '
                     . 'chown ' . $userGroup . ' ' . $releasesDirectory;
-                if (file_exists($symlink)) {
-                    $command.= ' && ' . 'chown -h ' . $userGroup . ' ' . $symlink;
-                }
                 $result = $this->runCommandRemote($command);
                 if (!$result) {
                     return $result;
                 }
             }
 
-            // Remove symlink if exists; create new symlink and change owner
-            $tmplink = $currentCopy . '.tmp';
-            $command = "ln -sfn {$currentCopy} {$tmplink} && mv -fT {$tmplink} {$symlink}";
+            // Switch symlink and change owner
+            $tmplink = $symlink . '.tmp';
+            $command = "ln -sfn {$currentCopy} {$tmplink}";
+            if ($resultFetch && $userGroup != '') {
+                $command.= " && chown -h {$userGroup} {$tmplink}";
+            }
+            $command.= " && mv -fT {$tmplink} {$symlink}";
             $result = $this->runCommandRemote($command);
 
             if ($result) {

--- a/Mage/Task/BuiltIn/Deployment/Strategy/RsyncTask.php
+++ b/Mage/Task/BuiltIn/Deployment/Strategy/RsyncTask.php
@@ -100,7 +100,9 @@ class RsyncTask extends BaseStrategyTaskAbstract implements IsReleaseAware
                  . $this->excludes($excludes) . ' '
                  . $this->excludesListFile($excludesListFilePath) . ' '
                  . $this->getConfig()->deployment('from') . ' '
-                 . $this->getConfig()->deployment('user') . '@' . $this->getConfig()->getHostName() . ':' . $deployToDirectory;
+                 . ( $this->getConfig()->deployment('user') ? $this->getConfig()->deployment('user') . '@' : '' )
+                 . $this->getConfig()->getHostName() . ':' . $deployToDirectory;
+
         $result = $this->runCommandLocal($command);
 
         return $result;

--- a/Mage/Task/BuiltIn/Releases/RollbackTask.php
+++ b/Mage/Task/BuiltIn/Releases/RollbackTask.php
@@ -136,14 +136,12 @@ class RollbackTask extends AbstractTask implements IsReleaseAware
                     $userGroup = '';
                     $resultFetch = $this->runCommandRemote('ls -ld ' . $rollbackTo . ' | awk \'{print \$3":"\$4}\'', $userGroup);
 
-                    $tmplink = $rollbackTo . '.tmp';
-                    $command = 'ln -sfn ' . $currentCopy . ' ' . $tmplink
-                             . ' && '
-                             . 'mv -T ' . $tmplink . ' ' . $symlink;
-
-                    if ($resultFetch) {
-                        $command .= ' && chown -h ' . $userGroup . ' ' . $symlink;
+                    $tmplink = $symlink . '.tmp';
+                    $command = "ln -sfn {$currentCopy} {$tmplink}";
+                    if ($resultFetch && $userGroup) {
+                        $command .= " && chown -h {$userGroup} ${tmplink}";
                     }
+                    $command .= " && mv -T {$tmplink} {$symlink}";
 
                     $result = $this->runCommandRemote($command);
 


### PR DESCRIPTION
when releasing or rolling back, don’t chown the »current« symlink before we changed / created it.
also don’t screw up the ssh cmdline if no username was given.