### PR TITLE
The timezone should be system dependent

### DIFF
--- a/bin/mage
+++ b/bin/mage
@@ -9,7 +9,9 @@
 * file that was distributed with this source code.
 */
 
-date_default_timezone_set('UTC');
+if(empty(ini_get('date.timezone'))){
+    date_default_timezone_set('UTC');
+}
 
 $baseDir = dirname(dirname(__FILE__));
 

--- a/bin/mage
+++ b/bin/mage
@@ -9,7 +9,7 @@
 * file that was distributed with this source code.
 */
 
-if(empty(ini_get('date.timezone'))){
+if (empty(ini_get('date.timezone'))) {
     date_default_timezone_set('UTC');
 }
 


### PR DESCRIPTION
If the timezone is set in the php cli ini file, mage should use that one instead of the default UTC