### PR TITLE
resultFetch is always false when owner is specified in config

### DIFF
--- a/Mage/Task/BuiltIn/Deployment/ReleaseTask.php
+++ b/Mage/Task/BuiltIn/Deployment/ReleaseTask.php
@@ -74,7 +74,7 @@ class ReleaseTask extends AbstractTask implements IsReleaseAware, SkipOnOverride
                 }
             }
 
-            if ($resultFetch && $userGroup != '') {
+            if ($userGroup != '') {
                 $command = 'chown -R ' . $userGroup . ' ' . $currentCopy
                     . ' && '
                     . 'chown ' . $userGroup . ' ' . $releasesDirectory;

--- a/Mage/Task/BuiltIn/Deployment/ReleaseTask.php
+++ b/Mage/Task/BuiltIn/Deployment/ReleaseTask.php
@@ -70,18 +70,16 @@ class ReleaseTask extends AbstractTask implements IsReleaseAware, SkipOnOverride
                     if (!empty($infoArray[3])) {
                         $group = $infoArray[3];
                     }
-                    $userGroup = $user . ':' . $group;
                 }
+                $userGroup = $user . ':' . $group;
             }
 
-            if ($userGroup != '') {
-                $command = 'chown -R ' . $userGroup . ' ' . $currentCopy
-                    . ' && '
-                    . 'chown ' . $userGroup . ' ' . $releasesDirectory;
-                $result = $this->runCommandRemote($command);
-                if (!$result) {
-                    return $result;
-                }
+            $command = 'chown -R ' . $userGroup . ' ' . $currentCopy
+                . ' && '
+                . 'chown ' . $userGroup . ' ' . $releasesDirectory;
+            $result = $this->runCommandRemote($command);
+            if (!$result) {
+                return $result;
             }
 
             // Switch symlink and change owner


### PR DESCRIPTION
If the "owner" is specified in environment configuration, the resultFetch value is never changed from false to true. Therefore checking for that before setting permissions is pointless.