### PR TITLE
Handle '--help' option for commands

### DIFF
--- a/Mage/Command/AbstractCommand.php
+++ b/Mage/Command/AbstractCommand.php
@@ -116,7 +116,7 @@ abstract class AbstractCommand
      */
     public function addUsageExample($snippet, $description = '')
     {
-        array_push($this->usageExamples, [$snippet, $description]);
+        array_push($this->usageExamples, array($snippet, $description));
 
         return $this;
     }

--- a/Mage/Command/AbstractCommand.php
+++ b/Mage/Command/AbstractCommand.php
@@ -86,20 +86,19 @@ abstract class AbstractCommand
 
         if (!empty($this->helpMessage)) {
             $output .= "\n";
-            $output .= $this->helpMessage . "\n";
+            $output .= "<cyan><bold>{$this->helpMessage}</bold></cyan>\n";
         }
 
         if (!empty($this->syntaxMessage)) {
             $output .= "\n";
-            $output .= "Syntax:\n";
-            $output .= $indent;
-            $output .= $this->syntaxMessage;
+            $output .= "<light_gray><bold>Syntax:</bold></light_gray>\n";
+            $output .= "$indent<light_green>{$this->syntaxMessage}</light_green>";
             $output .= "\n";
         }
 
         if (!empty($this->usageExamples)) {
             $output .= "\n";
-            $output .= "Usage examples:\n";
+            $output .= "<light_gray><bold>Usage examples:</bold></light_gray>\n";
             foreach ($this->usageExamples as $example) {
                 $snippet = $example[0];
                 $description = $example[1];
@@ -110,7 +109,7 @@ abstract class AbstractCommand
                     $output .= "\n$indent$indent";
                 }
 
-                $output .= $snippet;
+                $output .= "<green>$snippet</green>";
                 $output .= "\n";
             }
         }

--- a/Mage/Command/AbstractCommand.php
+++ b/Mage/Command/AbstractCommand.php
@@ -29,6 +29,7 @@ abstract class AbstractCommand
     private $helpMessage;
     private $usageExamples = [];
     private $syntaxMessage;
+    private $name;
 
     /**
      * Runs the Command
@@ -57,6 +58,13 @@ abstract class AbstractCommand
         return $this->config;
     }
 
+    public function setName($name)
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
     public function setHelpMessage($message)
     {
         $this->helpMessage = $message;
@@ -83,10 +91,15 @@ abstract class AbstractCommand
         $indent = str_repeat(" ", 4);
 
         $output = "";
+        if (!empty($this->name)) {
+            $output .= "\n";
+            $output .= "<cyan><bold>Command: </bold></cyan>";
+            $output .= $this->name;
+        }
 
         if (!empty($this->helpMessage)) {
             $output .= "\n";
-            $output .= "<cyan><bold>{$this->helpMessage}</bold></cyan>\n";
+            $output .= "<light_blue>{$this->helpMessage}</light_blue>\n";
         }
 
         if (!empty($this->syntaxMessage)) {

--- a/Mage/Command/AbstractCommand.php
+++ b/Mage/Command/AbstractCommand.php
@@ -180,6 +180,12 @@ abstract class AbstractCommand
             }
         }
 
+        if (empty($output)) {
+            $output .= "\n";
+            $output .= "<red><bold>Sorry, there's no help for this command at the moment.</bold></red>";
+            $output .= "\n";
+        }
+
         return $output;
     }
 }

--- a/Mage/Command/AbstractCommand.php
+++ b/Mage/Command/AbstractCommand.php
@@ -26,6 +26,10 @@ abstract class AbstractCommand
      */
     protected $config = null;
 
+    private $helpMessage;
+    private $usageExamples = [];
+    private $syntaxMessage;
+
     /**
      * Runs the Command
      * @return integer exit code
@@ -51,5 +55,66 @@ abstract class AbstractCommand
     public function getConfig()
     {
         return $this->config;
+    }
+
+    public function setHelpMessage($message)
+    {
+        $this->helpMessage = $message;
+
+        return $this;
+    }
+
+    public function addUsageExample($snippet, $description = '')
+    {
+        array_push($this->usageExamples, [$snippet, $description]);
+
+        return $this;
+    }
+
+    public function setSyntaxMessage($message)
+    {
+        $this->syntaxMessage = $message;
+
+        return $this;
+    }
+
+    public function getInfoMessage()
+    {
+        $indent = str_repeat(" ", 4);
+
+        $output = "";
+
+        if (!empty($this->helpMessage)) {
+            $output .= "\n";
+            $output .= $this->helpMessage . "\n";
+        }
+
+        if (!empty($this->syntaxMessage)) {
+            $output .= "\n";
+            $output .= "Syntax:\n";
+            $output .= $indent;
+            $output .= $this->syntaxMessage;
+            $output .= "\n";
+        }
+
+        if (!empty($this->usageExamples)) {
+            $output .= "\n";
+            $output .= "Usage examples:\n";
+            foreach ($this->usageExamples as $example) {
+                $snippet = $example[0];
+                $description = $example[1];
+                $output .= "$indent* ";
+                if (!empty($description)) {
+                    $description = rtrim($description, ': ') . ":";
+                    $output .= $description;
+                    $output .= "\n$indent$indent";
+                }
+
+                $output .= $snippet;
+                $output .= "\n";
+            }
+        }
+
+        return $output;
     }
 }

--- a/Mage/Command/AbstractCommand.php
+++ b/Mage/Command/AbstractCommand.php
@@ -26,9 +26,32 @@ abstract class AbstractCommand
      */
     protected $config = null;
 
+    /**
+     * Command's help message
+     *
+     * @var string
+     */
     private $helpMessage;
-    private $usageExamples = [];
+
+    /**
+     * Usage examples.
+     *
+     * @var array
+     */
+    private $usageExamples = array();
+
+    /**
+     * Command's syntax message
+     *
+     * @var string
+     */
     private $syntaxMessage;
+
+    /**
+     * Command name
+     *
+     * @var string
+     */
     private $name;
 
     /**
@@ -58,6 +81,12 @@ abstract class AbstractCommand
         return $this->config;
     }
 
+    /**
+     * Sets command name
+     *
+     * @param string $name Command name
+     * @return $this
+     */
     public function setName($name)
     {
         $this->name = $name;
@@ -65,6 +94,12 @@ abstract class AbstractCommand
         return $this;
     }
 
+    /**
+     * Sets command's help message
+     *
+     * @param string $message Command's help message
+     * @return $this
+     */
     public function setHelpMessage($message)
     {
         $this->helpMessage = $message;
@@ -72,6 +107,13 @@ abstract class AbstractCommand
         return $this;
     }
 
+    /**
+     * Adds command's usage example
+     *
+     * @param string $snippet Example's snippet
+     * @param string $description Example's description
+     * @return $this
+     */
     public function addUsageExample($snippet, $description = '')
     {
         array_push($this->usageExamples, [$snippet, $description]);
@@ -79,6 +121,12 @@ abstract class AbstractCommand
         return $this;
     }
 
+    /**
+     * Sets command's syntax message
+     *
+     * @param string $message Syntax message
+     * @return $this
+     */
     public function setSyntaxMessage($message)
     {
         $this->syntaxMessage = $message;
@@ -86,6 +134,11 @@ abstract class AbstractCommand
         return $this;
     }
 
+    /**
+     * Returns formatted command info
+     *
+     * @return string
+     */
     public function getInfoMessage()
     {
         $indent = str_repeat(" ", 4);

--- a/Mage/Command/BuiltIn/AddCommand.php
+++ b/Mage/Command/BuiltIn/AddCommand.php
@@ -23,6 +23,21 @@ use Exception;
  */
 class AddCommand extends AbstractCommand
 {
+    public function __construct()
+    {
+        $this->setName('Add command')
+            ->setHelpMessage('Generates new config for Magallanes. For now, only adding a environment is possible')
+            ->setSyntaxMessage('mage add [environment] [--name=env_name] [--enableReleases]')
+            ->addUsageExample(
+                'mage add environment --name=production',
+                'Add a production environment'
+            )
+            ->addUsageExample(
+                'mage add environment --name=qa --enableReleases',
+                'Add a QA environment and enable releasing'
+            );
+    }
+
     /**
      * Adds new Configuration Elements
      * @see \Mage\Command\AbstractCommand::run()

--- a/Mage/Command/BuiltIn/CompileCommand.php
+++ b/Mage/Command/BuiltIn/CompileCommand.php
@@ -21,6 +21,13 @@ use Mage\Compiler;
  */
 class CompileCommand extends AbstractCommand
 {
+    public function __construct()
+    {
+        $this->setName('Compile command')
+            ->setHelpMessage('Compiles Magallanes to mage.phar file')
+            ->setSyntaxMessage('mage compile');
+    }
+
     /**
      * @var Compiler
      */

--- a/Mage/Command/BuiltIn/CompileCommand.php
+++ b/Mage/Command/BuiltIn/CompileCommand.php
@@ -21,13 +21,6 @@ use Mage\Compiler;
  */
 class CompileCommand extends AbstractCommand
 {
-    public function __construct()
-    {
-        $this->setName('Compile command')
-            ->setHelpMessage('Compiles Magallanes to mage.phar file')
-            ->setSyntaxMessage('mage compile');
-    }
-
     /**
      * @var Compiler
      */
@@ -40,6 +33,10 @@ class CompileCommand extends AbstractCommand
         }
 
         $this->compiler = $compiler;
+
+        $this->setName('Compile command')
+            ->setHelpMessage('Compiles Magallanes to mage.phar file')
+            ->setSyntaxMessage('mage compile');
     }
 
     /**

--- a/Mage/Command/BuiltIn/DeployCommand.php
+++ b/Mage/Command/BuiltIn/DeployCommand.php
@@ -103,6 +103,22 @@ class DeployCommand extends AbstractCommand implements RequiresEnvironment
      */
     protected static $failedTasks = 0;
 
+    public function __construct()
+    {
+        $this->setName('Deploy command')
+            ->setHelpMessage('Deploys the project into target environment')
+            ->setSyntaxMessage('mage deploy to:[environment_name]')
+            ->addUsageExample(
+                'mage deploy to:production',
+                'Deploy the project into <bold>production</bold> environment'
+            )
+            ->addUsageExample(
+                'mage deploy to:production --overrideRelease',
+                'Deploy the project into <bold>production</bold> environment '
+                . 'but skip <bold>SkipOnOverride</bold> aware tasks'
+            );
+    }
+
     /**
      * Returns the Status of the Deployment
      *

--- a/Mage/Command/BuiltIn/InitCommand.php
+++ b/Mage/Command/BuiltIn/InitCommand.php
@@ -20,6 +20,20 @@ use Mage\Console;
  */
 class InitCommand extends AbstractCommand
 {
+    public function __construct()
+    {
+        $this->setName('Initialize command')
+            ->setHelpMessage('Initialize Magallanes project, create .mage directory with starter configs')
+            ->setSyntaxMessage('mage init --name=[project_name] [--email=[author_email]]')
+            ->addUsageExample(
+                'mage init --name="My awesome project"',
+                'Initialize "My awesome project" configuration'
+            )
+            ->addUsageExample(
+                'mage init --name="My project" --email="john.smith@example.com"',
+                'Initialize "My project" configuration with email notification enabled for john.smith@example.com'
+            );
+    }
 
     /**
      * Command for Initalize a new Configuration Proyect

--- a/Mage/Command/BuiltIn/InstallCommand.php
+++ b/Mage/Command/BuiltIn/InstallCommand.php
@@ -20,6 +20,24 @@ use Mage\Console;
  */
 class InstallCommand extends AbstractCommand
 {
+    public function __construct()
+    {
+        $this->setName('Install command')
+            ->setHelpMessage(
+                'Installs Magallanes system-widely.'
+                . ' By default, Magallanes\' going to be installed in /opt/magallanes'
+            )
+            ->setSyntaxMessage('mage install [--installDir=[install_directory]] [--systemWide]')
+            ->addUsageExample(
+                'mage install --installDir=/src/projects/Magellanes',
+                'Install Magallanes at /src/projects/Magallanes directory'
+            )
+            ->addUsageExample(
+                'mage install --systemWide',
+                'Install Magallanes at default directory and creates a symlink in /usr/bin/mage'
+            );
+    }
+
     /**
      * Installs Magallanes
      * @see \Mage\Command\AbstractCommand::run()

--- a/Mage/Command/BuiltIn/ListCommand.php
+++ b/Mage/Command/BuiltIn/ListCommand.php
@@ -23,6 +23,17 @@ use Exception;
  */
 class ListCommand extends AbstractCommand
 {
+    public function __construct()
+    {
+        $this->setName('List command')
+            ->setHelpMessage('List available configurations. For now, only environments listing available')
+            ->setSyntaxMessage('mage list [environments]')
+            ->addUsageExample(
+                'mage list environments',
+                'List currently configured environments'
+            );
+    }
+
     /**
      * Command for Listing Configuration Elements
      * @see \Mage\Command\AbstractCommand::run()

--- a/Mage/Command/BuiltIn/LockCommand.php
+++ b/Mage/Command/BuiltIn/LockCommand.php
@@ -21,6 +21,21 @@ use Mage\Console;
  */
 class LockCommand extends AbstractCommand implements RequiresEnvironment
 {
+    public function __construct()
+    {
+        $this->setName('Lock command')
+            ->setHelpMessage(
+                "Locks the deployment to given environment and creates a lock file "
+                . "with lock reason and lock performer.\n"
+                . "You are going to be prompted to provide this information"
+            )
+            ->setSyntaxMessage('mage lock to:[environment_name]')
+            ->addUsageExample(
+                'mage lock to:production',
+                'Create a lock to production environment deployment'
+            );
+    }
+
     /**
      * Locks the Deployment to a Environment
      * @see \Mage\Command\AbstractCommand::run()

--- a/Mage/Command/BuiltIn/ReleasesCommand.php
+++ b/Mage/Command/BuiltIn/ReleasesCommand.php
@@ -22,6 +22,36 @@ use Mage\Console;
  */
 class ReleasesCommand extends AbstractCommand implements RequiresEnvironment
 {
+    public function __construct()
+    {
+        $this->setName('Releases management command')
+            ->setHelpMessage('Manages releases')
+            ->setSyntaxMessage(
+                'mage releases [list|rollback [--release=[release_id]]] '
+                . 'to:[environment_name] [--deleteCurrent]'
+            )
+            ->addUsageExample(
+                'mage releases list to:production',
+                'List releases on production environment'
+            )
+            ->addUsageExample(
+                'mage releases rollback --release=20120101172148 to:production',
+                'Rollback 20120101172148 release on production environment'
+            )
+            ->addUsageExample(
+                'mage releases rollback --release=-1 to:production',
+                'Rollback <bold>list release -1</bold> release on production environment'
+            )
+            ->addUsageExample(
+                'mage releases rollback --release=0 to:production',
+                'Rollback last release on production environment'
+            )
+            ->addUsageExample(
+                'mage releases rollback -1 to:production --deleteCurrent',
+                'Rollbacks the <bold>last release -1</bold> release and removes current release'
+            );
+    }
+
     /**
      * List the Releases, Rollback to a Release
      * @see \Mage\Command\AbstractCommand::run()

--- a/Mage/Command/BuiltIn/RollbackCommand.php
+++ b/Mage/Command/BuiltIn/RollbackCommand.php
@@ -22,6 +22,24 @@ use Mage\Console;
  */
 class RollbackCommand extends AbstractCommand implements RequiresEnvironment
 {
+    public function __construct()
+    {
+        $this->setName('Rollback command')
+            ->setHelpMessage('Rollbacks the release by given release id or index')
+            ->setSyntaxMessage('mage rollback [releaseId] to:[environment_name]')
+            ->addUsageExample(
+                'mage rollback 20120101172148 to:production',
+                'Rollbacks the 20120101172148 release on production environment'
+            )
+            ->addUsageExample(
+                'mage rollback -1 to:production',
+                'Rollbacks the <bold>last release -1</bold> release'
+            )
+            ->addUsageExample(
+                'mage rollback -1 to:production --deleteCurrent',
+                'Rollbacks the <bold>last release -1</bold> release and removes current release'
+            );
+    }
     /**
      * Rollback a release
      * @see \Mage\Command\AbstractCommand::run()

--- a/Mage/Command/BuiltIn/UnlockCommand.php
+++ b/Mage/Command/BuiltIn/UnlockCommand.php
@@ -21,6 +21,17 @@ use Mage\Console;
  */
 class UnlockCommand extends AbstractCommand implements RequiresEnvironment
 {
+    public function __construct()
+    {
+        $this->setName('Unlock command')
+            ->setHelpMessage('Unlocks deployment for given environment')
+            ->setSyntaxMessage('mage unlock to:[environment_name]')
+            ->addUsageExample(
+                'mage unlock to:production',
+                'Removes the lock form production environment deployment'
+            );
+    }
+
     /**
      * Unlocks an Environment
      * @see \Mage\Command\AbstractCommand::run()

--- a/Mage/Command/BuiltIn/UpdateCommand.php
+++ b/Mage/Command/BuiltIn/UpdateCommand.php
@@ -21,6 +21,13 @@ use Mage\Console;
  */
 class UpdateCommand extends AbstractCommand
 {
+    public function __construct()
+    {
+        $this->setName('Update command')
+            ->setHelpMessage('Updates the SCM base code')
+            ->setSyntaxMessage('mage update');
+    }
+
     /**
      * Updates the SCM Base Code
      * @see \Mage\Command\AbstractCommand::run()

--- a/Mage/Command/BuiltIn/UpgradeCommand.php
+++ b/Mage/Command/BuiltIn/UpgradeCommand.php
@@ -20,6 +20,13 @@ use Mage\Console;
  */
 class UpgradeCommand extends AbstractCommand
 {
+    public function __construct()
+    {
+        $this->setName('Upgrade command')
+            ->setHelpMessage('Upgrades Magallanes')
+            ->setSyntaxMessage('mage upgrade');
+    }
+
     /**
      * Source for downloading
      * @var string

--- a/Mage/Command/BuiltIn/VersionCommand.php
+++ b/Mage/Command/BuiltIn/VersionCommand.php
@@ -20,6 +20,12 @@ use Mage\Console;
  */
 class VersionCommand extends AbstractCommand
 {
+    public function __construct()
+    {
+        $this->setName('Version command')
+            ->setHelpMessage('Displays the current version of Magallanes')
+            ->setSyntaxMessage('mage version');
+    }
     /**
      * Display the Magallanes Version
      * @see \Mage\Command\AbstractCommand::run()

--- a/Mage/Console.php
+++ b/Mage/Console.php
@@ -13,6 +13,7 @@ namespace Mage;
 use Mage\Command\Factory;
 use Mage\Command\RequiresEnvironment;
 use Mage\Console\Colors;
+
 use Exception;
 use RecursiveDirectoryIterator;
 use SplFileInfo;
@@ -94,6 +95,7 @@ class Console
         try {
             // Load configuration
             $config->load($arguments);
+
         } catch (Exception $exception) {
             $configError = $exception->getMessage();
         }
@@ -117,6 +119,7 @@ class Console
         if ($showGreetings) {
             if (!self::$logEnabled) {
                 self::output('Starting <blue>Magallanes</blue>', 0, 2);
+
             } else {
                 self::output('Starting <blue>Magallanes</blue>', 0, 1);
                 self::log("Logging enabled");
@@ -127,15 +130,20 @@ class Console
         // Run Command - Check if there is a Configuration Error
         if ($configError !== false) {
             self::output('<red>' . $configError . '</red>', 1, 2);
+
         } else {
             // Run Command and check for Command Requirements
             try {
                 $command = Factory::get($commandName, $config);
 
-                if ($command instanceof RequiresEnvironment) {
-                    if ($config->getEnvironment() === false) {
-                        throw new Exception('You must specify an environment for this command.');
-                    }
+                if ($config->getParameter('help')) {
+                    self::output($command->getInfoMessage(), 2);
+
+                    return 0;
+                }
+
+                if ($command instanceof RequiresEnvironment && $config->getEnvironment() === false) {
+                    throw new Exception('You must specify an environment for this command.');
                 }
 
                 // Run the Command
@@ -306,4 +314,5 @@ class Console
             || self::$config->general('verbose_logging')
             || self::$config->environmentConfig('verbose_logging', false);
     }
+
 }

--- a/tests/MageTest/Command/AbstractCommandTest.php
+++ b/tests/MageTest/Command/AbstractCommandTest.php
@@ -229,6 +229,14 @@ class AbstractCommandTest extends BaseTest
                     . "        <green>mage example</green>\n"
                     . "    * Runs the command with lights:\n"
                     . "        <green>mage example light</green>\n"
+            ),
+            "no_info_at_all" => array(
+                'name' => '',
+                'helpMessage' => '',
+                'examples' => array(),
+                'syntax' => '',
+                'output' => "\n"
+                    . "<red><bold>Sorry, there's no help for this command at the moment.</bold></red>\n"
             )
         );
     }

--- a/tests/MageTest/Command/AbstractCommandTest.php
+++ b/tests/MageTest/Command/AbstractCommandTest.php
@@ -44,4 +44,175 @@ class AbstractCommandTest extends BaseTest
         $configMock = $this->getMock('Mage\Config');
         $this->doTestGetter($this->abstractCommand, 'config', $configMock);
     }
+
+    public function infoMessageProvider()
+    {
+        return [
+            'happy_path' => [
+                'helpMessage' => 'This command does everything you want to',
+                'examples' => [
+                    [
+                        'snippet' => 'mage example',
+                        'description' => 'Default command'
+                    ],
+                    [
+                        'snippet' => 'mage example light',
+                        'description' => 'Runs the command with lights'
+                    ]
+                ],
+                'syntax' => 'mage example [light]',
+                'output' => "\n"
+                    . "This command does everything you want to\n"
+                    . "\n"
+                    . "Syntax:\n"
+                    . "    mage example [light]\n"
+                    . "\n"
+                    . "Usage examples:\n"
+                    . "    * Default command:\n"
+                    . "        mage example\n"
+                    . "    * Runs the command with lights:\n"
+                    . "        mage example light\n"
+            ],
+            'no_help_message' => [
+                'helpMessage' => '',
+                'examples' => [
+                    [
+                        'snippet' => 'mage example',
+                        'description' => 'Default command'
+                    ],
+                    [
+                        'snippet' => 'mage example light',
+                        'description' => 'Runs the command with lights'
+                    ]
+                ],
+                'syntax' => 'mage example [light]',
+                'output' => "\n"
+                    . "Syntax:\n"
+                    . "    mage example [light]\n"
+                    . "\n"
+                    . "Usage examples:\n"
+                    . "    * Default command:\n"
+                    . "        mage example\n"
+                    . "    * Runs the command with lights:\n"
+                    . "        mage example light\n"
+            ],
+            'no_examples' => [
+                'helpMessage' => 'This command does everything you want to',
+                'examples' => [],
+                'syntax' => 'mage example [light]',
+                'output' => "\n"
+                    . "This command does everything you want to\n"
+                    . "\n"
+                    . "Syntax:\n"
+                    . "    mage example [light]\n"
+            ],
+            "no_syntax" => [
+                'helpMessage' => 'This command does everything you want to',
+                'examples' => [
+                    [
+                        'snippet' => 'mage example',
+                        'description' => 'Default command'
+                    ],
+                    [
+                        'snippet' => 'mage example light',
+                        'description' => 'Runs the command with lights'
+                    ]
+                ],
+                'syntax' => '',
+                'output' => "\n"
+                    . "This command does everything you want to\n"
+                    . "\n"
+                    . "Usage examples:\n"
+                    . "    * Default command:\n"
+                    . "        mage example\n"
+                    . "    * Runs the command with lights:\n"
+                    . "        mage example light\n"
+            ],
+            "stripping_colons" => [
+                'helpMessage' => 'This command does everything you want to',
+                'examples' => [
+                    [
+                        'snippet' => 'mage example',
+                        'description' => 'Default command:'
+                    ],
+                    [
+                        'snippet' => 'mage example light',
+                        'description' => 'Runs the command with lights:'
+                    ]
+                ],
+                'syntax' => 'mage example [light]',
+                'output' => "\n"
+                    . "This command does everything you want to\n"
+                    . "\n"
+                    . "Syntax:\n"
+                    . "    mage example [light]\n"
+                    . "\n"
+                    . "Usage examples:\n"
+                    . "    * Default command:\n"
+                    . "        mage example\n"
+                    . "    * Runs the command with lights:\n"
+                    . "        mage example light\n"
+            ],
+            "only_help" => [
+                'helpMessage' => 'This command does everything you want to',
+                'examples' => [],
+                'syntax' => '',
+                'output' => "\n"
+                    . "This command does everything you want to\n"
+            ],
+            "only_examples" => [
+                'helpMessage' => '',
+                'examples' => [
+                    [
+                        'snippet' => 'mage example',
+                        'description' => 'Default command'
+                    ],
+                    [
+                        'snippet' => 'mage example light',
+                        'description' => 'Runs the command with lights'
+                    ]
+                ],
+                'syntax' => '',
+                'output' => "\n"
+                    . "Usage examples:\n"
+                    . "    * Default command:\n"
+                    . "        mage example\n"
+                    . "    * Runs the command with lights:\n"
+                    . "        mage example light\n"
+            ],
+            "only_syntax" => [
+                'helpMessage' => '',
+                'examples' => [],
+                'syntax' => 'mage example [light]',
+                'output' => "\n"
+                    . "Syntax:\n"
+                    . "    mage example [light]\n"
+            ]
+        ];
+    }
+
+    /**
+     * @covers ::getInfoMessage
+     * @covers ::setHelpMessage
+     * @covers ::addUsageExample
+     * @covers ::setSyntaxMessage
+     *
+     * @dataProvider infoMessageProvider
+     */
+    public function testGetInfoMessage($helpMessage, $examples, $syntax, $expectedMessage)
+    {
+        /** @var AbstractCommand $command */
+        $command = $this->getMockForAbstractClass('Mage\Command\AbstractCommand');
+
+        foreach ($examples as $example) {
+            $command->addUsageExample($example['snippet'], $example['description']);
+        }
+
+        $command->setHelpMessage($helpMessage);
+        $command->setSyntaxMessage($syntax);
+
+        $actualMessage = $command->getInfoMessage();
+        $this->assertEquals($expectedMessage, $actualMessage);
+
+    }
 }

--- a/tests/MageTest/Command/AbstractCommandTest.php
+++ b/tests/MageTest/Command/AbstractCommandTest.php
@@ -246,6 +246,7 @@ class AbstractCommandTest extends BaseTest
      * @covers ::setHelpMessage
      * @covers ::addUsageExample
      * @covers ::setSyntaxMessage
+     * @covers ::setName
      *
      * @dataProvider infoMessageProvider
      */

--- a/tests/MageTest/Command/AbstractCommandTest.php
+++ b/tests/MageTest/Command/AbstractCommandTest.php
@@ -49,6 +49,7 @@ class AbstractCommandTest extends BaseTest
     {
         return [
             'happy_path' => [
+                'name' => 'Example command',
                 'helpMessage' => 'This command does everything you want to',
                 'examples' => [
                     [
@@ -62,7 +63,8 @@ class AbstractCommandTest extends BaseTest
                 ],
                 'syntax' => 'mage example [light]',
                 'output' => "\n"
-                    . "<cyan><bold>This command does everything you want to</bold></cyan>\n"
+                    . "<cyan><bold>Command: </bold></cyan>Example command\n"
+                    . "<light_blue>This command does everything you want to</light_blue>\n"
                     . "\n"
                     . "<light_gray><bold>Syntax:</bold></light_gray>\n"
                     . "    <light_green>mage example [light]</light_green>\n"
@@ -74,6 +76,7 @@ class AbstractCommandTest extends BaseTest
                     . "        <green>mage example light</green>\n"
             ],
             'no_help_message' => [
+                'name' => 'Example command',
                 'helpMessage' => '',
                 'examples' => [
                     [
@@ -87,6 +90,7 @@ class AbstractCommandTest extends BaseTest
                 ],
                 'syntax' => 'mage example [light]',
                 'output' => "\n"
+                    . "<cyan><bold>Command: </bold></cyan>Example command\n"
                     . "<light_gray><bold>Syntax:</bold></light_gray>\n"
                     . "    <light_green>mage example [light]</light_green>\n"
                     . "\n"
@@ -97,16 +101,19 @@ class AbstractCommandTest extends BaseTest
                     . "        <green>mage example light</green>\n"
             ],
             'no_examples' => [
+                'name' => 'Example command',
                 'helpMessage' => 'This command does everything you want to',
                 'examples' => [],
                 'syntax' => 'mage example [light]',
                 'output' => "\n"
-                    . "<cyan><bold>This command does everything you want to</bold></cyan>\n"
+                    . "<cyan><bold>Command: </bold></cyan>Example command\n"
+                    . "<light_blue>This command does everything you want to</light_blue>\n"
                     . "\n"
                     . "<light_gray><bold>Syntax:</bold></light_gray>\n"
                     . "    <light_green>mage example [light]</light_green>\n"
             ],
             "no_syntax" => [
+                'name' => 'Example command',
                 'helpMessage' => 'This command does everything you want to',
                 'examples' => [
                     [
@@ -120,7 +127,8 @@ class AbstractCommandTest extends BaseTest
                 ],
                 'syntax' => '',
                 'output' => "\n"
-                    . "<cyan><bold>This command does everything you want to</bold></cyan>\n"
+                    . "<cyan><bold>Command: </bold></cyan>Example command\n"
+                    . "<light_blue>This command does everything you want to</light_blue>\n"
                     . "\n"
                     . "<light_gray><bold>Usage examples:</bold></light_gray>\n"
                     . "    * Default command:\n"
@@ -129,20 +137,22 @@ class AbstractCommandTest extends BaseTest
                     . "        <green>mage example light</green>\n"
             ],
             "stripping_colons" => [
+                'name' => 'Example command',
                 'helpMessage' => 'This command does everything you want to',
                 'examples' => [
                     [
                         'snippet' => 'mage example',
-                        'description' => 'Default command:'
+                        'description' => 'Default command : '
                     ],
                     [
                         'snippet' => 'mage example light',
-                        'description' => 'Runs the command with lights:'
+                        'description' => 'Runs the command with lights:  '
                     ]
                 ],
                 'syntax' => 'mage example [light]',
                 'output' => "\n"
-                    . "<cyan><bold>This command does everything you want to</bold></cyan>\n"
+                    . "<cyan><bold>Command: </bold></cyan>Example command\n"
+                    . "<light_blue>This command does everything you want to</light_blue>\n"
                     . "\n"
                     . "<light_gray><bold>Syntax:</bold></light_gray>\n"
                     . "    <light_green>mage example [light]</light_green>\n"
@@ -154,13 +164,16 @@ class AbstractCommandTest extends BaseTest
                     . "        <green>mage example light</green>\n"
             ],
             "only_help" => [
+                'name' => 'Example command',
                 'helpMessage' => 'This command does everything you want to',
                 'examples' => [],
                 'syntax' => '',
                 'output' => "\n"
-                    . "<cyan><bold>This command does everything you want to</bold></cyan>\n"
+                    . "<cyan><bold>Command: </bold></cyan>Example command\n"
+                    . "<light_blue>This command does everything you want to</light_blue>\n"
             ],
             "only_examples" => [
+                'name' => 'Example command',
                 'helpMessage' => '',
                 'examples' => [
                     [
@@ -174,6 +187,7 @@ class AbstractCommandTest extends BaseTest
                 ],
                 'syntax' => '',
                 'output' => "\n"
+                    . "<cyan><bold>Command: </bold></cyan>Example command\n"
                     . "<light_gray><bold>Usage examples:</bold></light_gray>\n"
                     . "    * Default command:\n"
                     . "        <green>mage example</green>\n"
@@ -181,12 +195,40 @@ class AbstractCommandTest extends BaseTest
                     . "        <green>mage example light</green>\n"
             ],
             "only_syntax" => [
+                'name' => 'Example command',
                 'helpMessage' => '',
                 'examples' => [],
                 'syntax' => 'mage example [light]',
                 'output' => "\n"
+                    . "<cyan><bold>Command: </bold></cyan>Example command\n"
                     . "<light_gray><bold>Syntax:</bold></light_gray>\n"
                     . "    <light_green>mage example [light]</light_green>\n"
+            ],
+            "no_name" => [
+                'name' => '',
+                'helpMessage' => 'This command does everything you want to',
+                'examples' => [
+                    [
+                        'snippet' => 'mage example',
+                        'description' => 'Default command'
+                    ],
+                    [
+                        'snippet' => 'mage example light',
+                        'description' => 'Runs the command with lights'
+                    ]
+                ],
+                'syntax' => 'mage example [light]',
+                'output' => "\n"
+                    . "<light_blue>This command does everything you want to</light_blue>\n"
+                    . "\n"
+                    . "<light_gray><bold>Syntax:</bold></light_gray>\n"
+                    . "    <light_green>mage example [light]</light_green>\n"
+                    . "\n"
+                    . "<light_gray><bold>Usage examples:</bold></light_gray>\n"
+                    . "    * Default command:\n"
+                    . "        <green>mage example</green>\n"
+                    . "    * Runs the command with lights:\n"
+                    . "        <green>mage example light</green>\n"
             ]
         ];
     }
@@ -199,10 +241,12 @@ class AbstractCommandTest extends BaseTest
      *
      * @dataProvider infoMessageProvider
      */
-    public function testGetInfoMessage($helpMessage, $examples, $syntax, $expectedMessage)
+    public function testGetInfoMessage($name, $helpMessage, $examples, $syntax, $expectedMessage)
     {
         /** @var AbstractCommand $command */
         $command = $this->getMockForAbstractClass('Mage\Command\AbstractCommand');
+
+        $command->setName($name);
 
         foreach ($examples as $example) {
             $command->addUsageExample($example['snippet'], $example['description']);

--- a/tests/MageTest/Command/AbstractCommandTest.php
+++ b/tests/MageTest/Command/AbstractCommandTest.php
@@ -47,20 +47,20 @@ class AbstractCommandTest extends BaseTest
 
     public function infoMessageProvider()
     {
-        return [
-            'happy_path' => [
+        return array(
+            'happy_path' => array(
                 'name' => 'Example command',
                 'helpMessage' => 'This command does everything you want to',
-                'examples' => [
-                    [
+                'examples' => array(
+                    array(
                         'snippet' => 'mage example',
                         'description' => 'Default command'
-                    ],
-                    [
+                    ),
+                    array(
                         'snippet' => 'mage example light',
                         'description' => 'Runs the command with lights'
-                    ]
-                ],
+                    )
+                ),
                 'syntax' => 'mage example [light]',
                 'output' => "\n"
                     . "<cyan><bold>Command: </bold></cyan>Example command\n"
@@ -74,20 +74,20 @@ class AbstractCommandTest extends BaseTest
                     . "        <green>mage example</green>\n"
                     . "    * Runs the command with lights:\n"
                     . "        <green>mage example light</green>\n"
-            ],
-            'no_help_message' => [
+            ),
+            'no_help_message' => array(
                 'name' => 'Example command',
                 'helpMessage' => '',
-                'examples' => [
-                    [
+                'examples' => array(
+                    array(
                         'snippet' => 'mage example',
                         'description' => 'Default command'
-                    ],
-                    [
+                    ),
+                    array(
                         'snippet' => 'mage example light',
                         'description' => 'Runs the command with lights'
-                    ]
-                ],
+                    )
+                ),
                 'syntax' => 'mage example [light]',
                 'output' => "\n"
                     . "<cyan><bold>Command: </bold></cyan>Example command\n"
@@ -99,11 +99,11 @@ class AbstractCommandTest extends BaseTest
                     . "        <green>mage example</green>\n"
                     . "    * Runs the command with lights:\n"
                     . "        <green>mage example light</green>\n"
-            ],
-            'no_examples' => [
+            ),
+            'no_examples' => array(
                 'name' => 'Example command',
                 'helpMessage' => 'This command does everything you want to',
-                'examples' => [],
+                'examples' => array(),
                 'syntax' => 'mage example [light]',
                 'output' => "\n"
                     . "<cyan><bold>Command: </bold></cyan>Example command\n"
@@ -111,20 +111,20 @@ class AbstractCommandTest extends BaseTest
                     . "\n"
                     . "<light_gray><bold>Syntax:</bold></light_gray>\n"
                     . "    <light_green>mage example [light]</light_green>\n"
-            ],
-            "no_syntax" => [
+            ),
+            "no_syntax" => array(
                 'name' => 'Example command',
                 'helpMessage' => 'This command does everything you want to',
-                'examples' => [
-                    [
+                'examples' => array(
+                    array(
                         'snippet' => 'mage example',
                         'description' => 'Default command'
-                    ],
-                    [
+                    ),
+                    array(
                         'snippet' => 'mage example light',
                         'description' => 'Runs the command with lights'
-                    ]
-                ],
+                    )
+                ),
                 'syntax' => '',
                 'output' => "\n"
                     . "<cyan><bold>Command: </bold></cyan>Example command\n"
@@ -135,20 +135,20 @@ class AbstractCommandTest extends BaseTest
                     . "        <green>mage example</green>\n"
                     . "    * Runs the command with lights:\n"
                     . "        <green>mage example light</green>\n"
-            ],
-            "stripping_colons" => [
+            ),
+            "stripping_colons" => array(
                 'name' => 'Example command',
                 'helpMessage' => 'This command does everything you want to',
-                'examples' => [
-                    [
+                'examples' => array(
+                    array(
                         'snippet' => 'mage example',
                         'description' => 'Default command : '
-                    ],
-                    [
+                    ),
+                    array(
                         'snippet' => 'mage example light',
                         'description' => 'Runs the command with lights:  '
-                    ]
-                ],
+                    )
+                ),
                 'syntax' => 'mage example [light]',
                 'output' => "\n"
                     . "<cyan><bold>Command: </bold></cyan>Example command\n"
@@ -162,29 +162,29 @@ class AbstractCommandTest extends BaseTest
                     . "        <green>mage example</green>\n"
                     . "    * Runs the command with lights:\n"
                     . "        <green>mage example light</green>\n"
-            ],
-            "only_help" => [
+            ),
+            "only_help" => array(
                 'name' => 'Example command',
                 'helpMessage' => 'This command does everything you want to',
-                'examples' => [],
+                'examples' => array(),
                 'syntax' => '',
                 'output' => "\n"
                     . "<cyan><bold>Command: </bold></cyan>Example command\n"
                     . "<light_blue>This command does everything you want to</light_blue>\n"
-            ],
-            "only_examples" => [
+            ),
+            "only_examples" => array(
                 'name' => 'Example command',
                 'helpMessage' => '',
-                'examples' => [
-                    [
+                'examples' => array(
+                    array(
                         'snippet' => 'mage example',
                         'description' => 'Default command'
-                    ],
-                    [
+                    ),
+                    array(
                         'snippet' => 'mage example light',
                         'description' => 'Runs the command with lights'
-                    ]
-                ],
+                    )
+                ),
                 'syntax' => '',
                 'output' => "\n"
                     . "<cyan><bold>Command: </bold></cyan>Example command\n"
@@ -193,30 +193,30 @@ class AbstractCommandTest extends BaseTest
                     . "        <green>mage example</green>\n"
                     . "    * Runs the command with lights:\n"
                     . "        <green>mage example light</green>\n"
-            ],
-            "only_syntax" => [
+            ),
+            "only_syntax" => array(
                 'name' => 'Example command',
                 'helpMessage' => '',
-                'examples' => [],
+                'examples' => array(),
                 'syntax' => 'mage example [light]',
                 'output' => "\n"
                     . "<cyan><bold>Command: </bold></cyan>Example command\n"
                     . "<light_gray><bold>Syntax:</bold></light_gray>\n"
                     . "    <light_green>mage example [light]</light_green>\n"
-            ],
-            "no_name" => [
+            ),
+            "no_name" => array(
                 'name' => '',
                 'helpMessage' => 'This command does everything you want to',
-                'examples' => [
-                    [
+                'examples' => array(
+                    array(
                         'snippet' => 'mage example',
                         'description' => 'Default command'
-                    ],
-                    [
+                    ),
+                    array(
                         'snippet' => 'mage example light',
                         'description' => 'Runs the command with lights'
-                    ]
-                ],
+                    )
+                ),
                 'syntax' => 'mage example [light]',
                 'output' => "\n"
                     . "<light_blue>This command does everything you want to</light_blue>\n"
@@ -229,8 +229,8 @@ class AbstractCommandTest extends BaseTest
                     . "        <green>mage example</green>\n"
                     . "    * Runs the command with lights:\n"
                     . "        <green>mage example light</green>\n"
-            ]
-        ];
+            )
+        );
     }
 
     /**

--- a/tests/MageTest/Command/AbstractCommandTest.php
+++ b/tests/MageTest/Command/AbstractCommandTest.php
@@ -62,16 +62,16 @@ class AbstractCommandTest extends BaseTest
                 ],
                 'syntax' => 'mage example [light]',
                 'output' => "\n"
-                    . "This command does everything you want to\n"
+                    . "<cyan><bold>This command does everything you want to</bold></cyan>\n"
                     . "\n"
-                    . "Syntax:\n"
-                    . "    mage example [light]\n"
+                    . "<light_gray><bold>Syntax:</bold></light_gray>\n"
+                    . "    <light_green>mage example [light]</light_green>\n"
                     . "\n"
-                    . "Usage examples:\n"
+                    . "<light_gray><bold>Usage examples:</bold></light_gray>\n"
                     . "    * Default command:\n"
-                    . "        mage example\n"
+                    . "        <green>mage example</green>\n"
                     . "    * Runs the command with lights:\n"
-                    . "        mage example light\n"
+                    . "        <green>mage example light</green>\n"
             ],
             'no_help_message' => [
                 'helpMessage' => '',
@@ -87,24 +87,24 @@ class AbstractCommandTest extends BaseTest
                 ],
                 'syntax' => 'mage example [light]',
                 'output' => "\n"
-                    . "Syntax:\n"
-                    . "    mage example [light]\n"
+                    . "<light_gray><bold>Syntax:</bold></light_gray>\n"
+                    . "    <light_green>mage example [light]</light_green>\n"
                     . "\n"
-                    . "Usage examples:\n"
+                    . "<light_gray><bold>Usage examples:</bold></light_gray>\n"
                     . "    * Default command:\n"
-                    . "        mage example\n"
+                    . "        <green>mage example</green>\n"
                     . "    * Runs the command with lights:\n"
-                    . "        mage example light\n"
+                    . "        <green>mage example light</green>\n"
             ],
             'no_examples' => [
                 'helpMessage' => 'This command does everything you want to',
                 'examples' => [],
                 'syntax' => 'mage example [light]',
                 'output' => "\n"
-                    . "This command does everything you want to\n"
+                    . "<cyan><bold>This command does everything you want to</bold></cyan>\n"
                     . "\n"
-                    . "Syntax:\n"
-                    . "    mage example [light]\n"
+                    . "<light_gray><bold>Syntax:</bold></light_gray>\n"
+                    . "    <light_green>mage example [light]</light_green>\n"
             ],
             "no_syntax" => [
                 'helpMessage' => 'This command does everything you want to',
@@ -120,13 +120,13 @@ class AbstractCommandTest extends BaseTest
                 ],
                 'syntax' => '',
                 'output' => "\n"
-                    . "This command does everything you want to\n"
+                    . "<cyan><bold>This command does everything you want to</bold></cyan>\n"
                     . "\n"
-                    . "Usage examples:\n"
+                    . "<light_gray><bold>Usage examples:</bold></light_gray>\n"
                     . "    * Default command:\n"
-                    . "        mage example\n"
+                    . "        <green>mage example</green>\n"
                     . "    * Runs the command with lights:\n"
-                    . "        mage example light\n"
+                    . "        <green>mage example light</green>\n"
             ],
             "stripping_colons" => [
                 'helpMessage' => 'This command does everything you want to',
@@ -142,23 +142,23 @@ class AbstractCommandTest extends BaseTest
                 ],
                 'syntax' => 'mage example [light]',
                 'output' => "\n"
-                    . "This command does everything you want to\n"
+                    . "<cyan><bold>This command does everything you want to</bold></cyan>\n"
                     . "\n"
-                    . "Syntax:\n"
-                    . "    mage example [light]\n"
+                    . "<light_gray><bold>Syntax:</bold></light_gray>\n"
+                    . "    <light_green>mage example [light]</light_green>\n"
                     . "\n"
-                    . "Usage examples:\n"
+                    . "<light_gray><bold>Usage examples:</bold></light_gray>\n"
                     . "    * Default command:\n"
-                    . "        mage example\n"
+                    . "        <green>mage example</green>\n"
                     . "    * Runs the command with lights:\n"
-                    . "        mage example light\n"
+                    . "        <green>mage example light</green>\n"
             ],
             "only_help" => [
                 'helpMessage' => 'This command does everything you want to',
                 'examples' => [],
                 'syntax' => '',
                 'output' => "\n"
-                    . "This command does everything you want to\n"
+                    . "<cyan><bold>This command does everything you want to</bold></cyan>\n"
             ],
             "only_examples" => [
                 'helpMessage' => '',
@@ -174,19 +174,19 @@ class AbstractCommandTest extends BaseTest
                 ],
                 'syntax' => '',
                 'output' => "\n"
-                    . "Usage examples:\n"
+                    . "<light_gray><bold>Usage examples:</bold></light_gray>\n"
                     . "    * Default command:\n"
-                    . "        mage example\n"
+                    . "        <green>mage example</green>\n"
                     . "    * Runs the command with lights:\n"
-                    . "        mage example light\n"
+                    . "        <green>mage example light</green>\n"
             ],
             "only_syntax" => [
                 'helpMessage' => '',
                 'examples' => [],
                 'syntax' => 'mage example [light]',
                 'output' => "\n"
-                    . "Syntax:\n"
-                    . "    mage example [light]\n"
+                    . "<light_gray><bold>Syntax:</bold></light_gray>\n"
+                    . "    <light_green>mage example [light]</light_green>\n"
             ]
         ];
     }

--- a/tests/MageTest/Command/BuiltIn/CompileCommandTest.php
+++ b/tests/MageTest/Command/BuiltIn/CompileCommandTest.php
@@ -16,6 +16,7 @@ use malkusch\phpmock\MockBuilder;
  * @uses malkusch\phpmock\MockBuilder
  * @uses Mage\Console
  * @uses Mage\Console\Colors
+ * @uses Mage\Command\AbstractCommand
  */
 class CompileCommandTest extends BaseTest
 {

--- a/tests/MageTest/Command/BuiltIn/ListCommandTest.php
+++ b/tests/MageTest/Command/BuiltIn/ListCommandTest.php
@@ -93,6 +93,7 @@ class ListCommandTest extends BaseTest
     }
 
     /**
+     * @covers ::__construct
      * @covers ::run
      * @covers ::listEnvironments
      * @dataProvider listEnvironmentsProvider
@@ -109,6 +110,7 @@ class ListCommandTest extends BaseTest
     }
 
     /**
+     * @covers ::__construct
      * @covers ::run
      */
     public function testRunWithInvalidCommand()

--- a/tests/MageTest/Command/BuiltIn/LockCommandTest.php
+++ b/tests/MageTest/Command/BuiltIn/LockCommandTest.php
@@ -173,6 +173,7 @@ class LockCommandTest extends BaseTest
     }
 
     /**
+     * @covers ::__construct
      * @covers ::run
      * @dataProvider lockCommandProvider
      */

--- a/tests/MageTest/Command/BuiltIn/UnlockCommandTest.php
+++ b/tests/MageTest/Command/BuiltIn/UnlockCommandTest.php
@@ -98,6 +98,7 @@ class UnlockCommandTest extends BaseTest
     }
 
     /**
+     * @covers ::__construct
      * @covers ::run
      * @dataProvider runProvider
      */

--- a/tests/MageTest/Command/BuiltIn/VersionCommandTest.php
+++ b/tests/MageTest/Command/BuiltIn/VersionCommandTest.php
@@ -8,16 +8,18 @@ use MageTest\TestHelper\BaseTest;
 use PHPUnit_Framework_TestCase;
 
 /**
- * @coversDefaultClass Mage\Command\BuiltIn\VersionCommands
+ * @coversDefaultClass Mage\Command\BuiltIn\VersionCommand
  * @group Mage_Command_BuildIn_VersionCommand
  * @uses Mage\Console
  * @uses Mage\Console\Colors
+ * @uses Mage\Command\AbstractCommand
  */
 class VersionCommandTest extends BaseTest
 {
     /**
      * @group 175
-     * @covers Mage\Command\BuiltIn\VersionCommand::run()
+     * @covers ::__construct
+     * @covers ::run()
      */
     public function testRun()
     {


### PR DESCRIPTION
Hi Magallanes users! Welcome back after such long break :)
Some time ago I've started working on `--help` option for commands. I don't know why I have stopped contributing this idea. Fortunatelly, I've got everything on remote repo on my GitHub account, so I could continue my work :)
This PR includes only part of `--help` functionality. After running Magallanes binary with command and `--help` option, you should get description of the command such as that on following screenshot:
![zaznaczenie_032](https://cloud.githubusercontent.com/assets/1702899/7667857/309308fe-fc1b-11e4-8969-98b58249f76b.png)

There is much more to do than I thought before. Things that should be done in the nearest future includes:
* General `--help` for `mage` binary
* Option to specify command arguments and options (like in Symfony2 commands) to validate command calling and generate help message dynamically and avoid programmers effort in designing help messages
* Prepare help messages for other built-in commands (this PR includes help messages for only few of them)

Help message API includes following methods accessible in `AbstractCommand` class:
* `setName` - Name of the command (displayed after phrase _Command_)
* `setHelpMessage` - Short description of the command
* `setSyntaxMessage` - Displays the information how the command should be called properly
* `addUsageExample` - allows to add an usage example with short description what command does