### PR TITLE
Set branch revert as the last task on post deployment

### DIFF
--- a/Mage/Command/BuiltIn/DeployCommand.php
+++ b/Mage/Command/BuiltIn/DeployCommand.php
@@ -251,7 +251,7 @@ class DeployCommand extends AbstractCommand implements RequiresEnvironment
 
             // Change Branch Back
             if ($config->deployment('scm', false)) {
-                array_unshift($tasksToRun, 'scm/change-branch');
+                array_push($tasksToRun, 'scm/change-branch');
                 $config->addParameter('_changeBranchRevert');
             }
 


### PR DESCRIPTION
Changing order of the 'scm/change-branch' task to be the last task executed on post deployment stage.
This change allows to execute current branch tasks on post deployment stage.