### PR TITLE
Optional timezone configuration

### DIFF
--- a/Mage/Console.php
+++ b/Mage/Console.php
@@ -100,6 +100,9 @@ class Console
 
         // Command Option
         $commandName = $config->getArgument(0);
+        
+        // Timezone for logging
+        @date_default_timezone_set($config->general('timezone', 'UTC'));
 
         // Logging
         $showGreetings = true;


### PR DESCRIPTION
Reads an optional *timezone param* from `general.yml` to log with the correct datetime. Now is always writing the default `UTC` timezone, so my logs are 2h "delayed". The configuration is easy as hell:

```yaml
# /config/general.yml
# global settings
name: MyApp
email: mi@email.com
# ...more params
timezone: 'Europe/Madrid'
```

If none specified, default `UTC` will apply. The same result will apply if a wrong timezone is specified (p.e. 'asdfasd/asdfasd')

Signed-off-by: Dani Sancas <lord.sancas@gmail.com>