### PR TITLE
Adds tasks to manipulate Phinx database migrations

### DIFF
--- a/Mage/Task/BuiltIn/Database/Phinx/MigrateOrRollbackTask.php
+++ b/Mage/Task/BuiltIn/Database/Phinx/MigrateOrRollbackTask.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Mage\Task\BuiltIn\Database\Phinx;
+
+use Mage\Task\Releases\RollbackAware;
+
+/**
+ * Task for running available phinx migrations or rollbacking them if in a
+ * mage rollback context. You can use environment, configuration, parser &
+ * target options as described in the phinx documentation.
+ *
+ * Usage :
+ *   on-deploy:
+ *     - database/phinx/migrate-or-rollback: {phinx_cmd: /path/to/phinx, environment: development, configuration: phinx.php}
+ *
+ * You may also set the target version to migrate or rollback to at runtime in
+ * the command line by adding : phinx-target:20151002103807 and phinx_cmd in the
+ * general configuration.
+ *
+ * @author Jérémy Huet <jeremy.huet@gmail.com>
+ * @see http://docs.phinx.org/en/latest/commands.html
+ */
+class MigrateOrRollbackTask extends PhinxAbstractTask implements RollbackAware
+{
+    /**
+     * Returns the Title of the Task
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return 'Phinx migrate or rollback [built-in]';
+    }
+
+    /**
+     * Runs the task
+     *
+     * @return boolean
+     */
+    public function run()
+    {
+        $migrateOrRollback = $this->inRollback() ? 'rollback' : 'migrate';
+
+        return $this->runCommand($this->getPhinxCmd() . ' ' .$migrateOrRollback . ' ' . $this->getOptionsForCmd());
+    }
+}

--- a/Mage/Task/BuiltIn/Database/Phinx/MigrateTask.php
+++ b/Mage/Task/BuiltIn/Database/Phinx/MigrateTask.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Mage\Task\BuiltIn\Database\Phinx;
+
+/**
+ * Task for running available phinx migrations. You can use environment,
+ * configuration, parser & target options as described in the phinx
+ * documentation.
+ *
+ * Usage :
+ *   on-deploy:
+ *     - database/phinx/migrate: {phinx_cmd: /path/to/phinx, environment: development, configuration: phinx.php}
+ *
+ * You may also set the target version to migrate to at runtime in the command
+ * line by adding : phinx-target:20151002103807 and phinx_cmd in the general
+ * configuration.
+ *
+ * @author Jérémy Huet <jeremy.huet@gmail.com>
+ * @see http://docs.phinx.org/en/latest/commands.html
+ */
+class MigrateTask extends PhinxAbstractTask
+{
+    /**
+     * Returns the Title of the Task
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return 'Phinx migrate [built-in]';
+    }
+
+    /**
+     * Runs the task
+     *
+     * @return boolean
+     */
+    public function run()
+    {
+        if (! $this->inRollback()) {
+            return $this->runCommand($this->getPhinxCmd() . ' migrate ' . $this->getOptionsForCmd());
+        }
+
+        return true;
+    }
+}

--- a/Mage/Task/BuiltIn/Database/Phinx/PhinxAbstractTask.php
+++ b/Mage/Task/BuiltIn/Database/Phinx/PhinxAbstractTask.php
@@ -1,0 +1,187 @@
+<?php
+
+namespace Mage\Task\BuiltIn\Database\Phinx;
+
+use Mage\Task\AbstractTask;
+
+/**
+ * Abstract Task for Phinx
+ *
+ * @author Jérémy Huet <jeremy.huet@gmail.com>
+ */
+abstract class PhinxAbstractTask extends AbstractTask
+{
+    /**
+     * Configuration option.
+     *
+     * @var string
+     */
+    private $configuration;
+
+    /**
+     * Environnement option.
+     *
+     * @var string
+     */
+    private $environment;
+
+    /**
+     * Parser option.
+     *
+     * @var string
+     */
+    private $parser;
+
+    /**
+     * Target option.
+     *
+     * @var string
+     */
+    private $target;
+
+    /**
+     *
+     */
+    public function init()
+    {
+        foreach ($this->getOptionsNames() as $optionName) {
+            $this->$optionName = $this->getParameter($optionName);
+        }
+    }
+
+    /**
+     * @return string
+     */
+    protected function getPhinxCmd()
+    {
+        return $this->getParameter('phinx_cmd', $this->getConfig()->general('phinx_cmd', 'vendor/bin/phinx'));
+    }
+
+    /**
+     * @return string
+     */
+    protected function getOptionsForCmd()
+    {
+        $optionsForCmd = '';
+        foreach ($this->getOptionsNames() as $optionName) {
+            if ($this->$optionName) {
+                $optionsForCmd .= '--' . $optionName . ' ' . $this->$optionName . ' ';
+            }
+        }
+
+        // Will add extra options to command line coming from the cli
+        foreach ($this->getCliOptionsNames() as $argument => $optionName) {
+            if ($value = $this->findArgument($argument)) {
+                $optionsForCmd .= '--' . $optionName . ' ' . $value;
+            }
+        }
+
+        return $optionsForCmd;
+    }
+
+    /**
+     * Tries to find an argument in the command line arguments.
+     *
+     * For example if command line argument has : phinx-target:20151009125450 it
+     * will find it and return 20151009125450 if $argument == 'phinx-target'.
+     *
+     * @param string $argument
+     *
+     * @return false|string
+     */
+    protected function findArgument($argument)
+    {
+        $value = false;
+        foreach ($this->getConfig()->getArguments() as $cmdArgument) {
+            if (strpos($cmdArgument . ':', $argument) === 0) {
+                $value = trim(substr($cmdArgument, strlen($argument . ':')));
+                break;
+            }
+        }
+
+        return $value;
+    }
+
+    /**
+     * @return array
+     */
+    protected function getOptionsNames()
+    {
+        return array('configuration', 'environment', 'parser', 'target');
+    }
+
+    /**
+     * Arguments that can be sent at runtime via the cli mage call like
+     * phinx-target:20151002103807
+     *
+     * @return array
+     */
+    protected function getCliOptionsNames()
+    {
+        return array('phinx-target' => 'target');
+    }
+
+    /**
+     * @return string
+     */
+    public function getConfiguration()
+    {
+        return $this->configuration;
+    }
+
+    /**
+     * @param string    $configuration
+     */
+    public function setConfiguration($configuration)
+    {
+        $this->configuration = $configuration;
+    }
+
+    /**
+     * @return string
+     */
+    public function getEnvironment()
+    {
+        return $this->environment;
+    }
+
+    /**
+     * @param string    $environment
+     */
+    public function setEnvironment($environment)
+    {
+        $this->environment = $environment;
+    }
+
+    /**
+     * @return string
+     */
+    public function getParser()
+    {
+        return $this->parser;
+    }
+
+    /**
+     * @param string    $parser
+     */
+    public function setParser($parser)
+    {
+        $this->parser = $parser;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTarget()
+    {
+        return $this->target;
+    }
+
+    /**
+     * @param string    $target
+     */
+    public function setTarget($target)
+    {
+        $this->target = $target;
+    }
+}

--- a/Mage/Task/BuiltIn/Database/Phinx/RollbackTask.php
+++ b/Mage/Task/BuiltIn/Database/Phinx/RollbackTask.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Mage\Task\BuiltIn\Database\Phinx;
+
+use Mage\Task\Releases\RollbackAware;
+
+/**
+ * Task for running available phinx rollbacks. You can use environment,
+ * configuration, parser & target options as described in the phinx
+ * documentation.
+ *
+ * Usage :
+ *   on-deploy:
+ *     - database/phinx/rollback: {phinx_cmd: /path/to/phinx, environment: development, configuration: phinx.php, target: 20151002103807}
+ *
+ * You may also set the target version to rollback to at runtime in the command
+ * line by adding : phinx-target:20151002103807 and phinx_cmd in the general
+ * configuration.
+ *
+ * @author Jérémy Huet <jeremy.huet@gmail.com>
+ * @see http://docs.phinx.org/en/latest/commands.html
+ */
+class RollbackTask extends PhinxAbstractTask implements RollbackAware
+{
+    /**
+     * Returns the Title of the Task
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return 'Phinx rollback [built-in]';
+    }
+
+    /**
+     * Runs the task only on rollback
+     *
+     * @return boolean
+     */
+    public function run()
+    {
+        if ($this->inRollback()) {
+            return $this->runCommand($this->getPhinxCmd() . ' rollback ' . $this->getOptionsForCmd());
+        }
+
+        return true;
+    }
+}

--- a/Mage/Task/BuiltIn/Database/Phinx/StatusTask.php
+++ b/Mage/Task/BuiltIn/Database/Phinx/StatusTask.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Mage\Task\BuiltIn\Database\Phinx;
+
+/**
+ * Task for running phinx status. It could be use to have the status in the
+ * mage logs. You can use environment, configuration, parser & target options
+ * as described in the phinx documentation.
+ *
+ * Usage :
+ *   on-deploy:
+ *     - database/phinx/status: {phinx_cmd: /path/to/phinx, environment: development, configuration: phinx.php}
+ *
+ * @author Jérémy Huet <jeremy.huet@gmail.com>
+ * @see http://docs.phinx.org/en/latest/commands.html
+ */
+class StatusTask extends PhinxAbstractTask
+{
+    /**
+     * Returns the Title of the Task
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return 'Phinx status [built-in]';
+    }
+
+    /**
+     * Runs the task
+     *
+     * @return boolean
+     */
+    public function run()
+    {
+        return $this->runCommand($this->getPhinxCmd() . ' status ' . $this->getOptionsForCmd());
+    }
+}


### PR DESCRIPTION
This PR adds 4 tasks that will allow you to manipulate [Phinx](https://phinx.org/) database migration scripts while deploying with Magallanes. Pay attention that, automatically executing database scripts can be dangerous. I highly suggest to make a copy of the database you're modifying before using any of this (maybe a Dump task might become handy one day :) ).

**[database/phinx/migrate](https://github.com/jhuet/Magallanes/blob/ea15df9257bc034ca2a57720da7a63e00927a8f1/Mage/Task/BuiltIn/Database/Phinx/MigrateTask.php)** : Will execute the Phinx [migrate](http://docs.phinx.org/en/latest/commands.html#the-migrate-command) command if deploying.

Options : 
- phinx_cmd: /path/to/phinx (can also be set in the general config)
- environment: development
- configuration: phinx.php
- parser: php
- target: 20120103083322 (can also be set at runtime in the CLI with phinx-target:20120103083322 argument) - if not provided, Phinx will migrate all new migrations.

**[database/phinx/rollback](https://github.com/jhuet/Magallanes/blob/ea15df9257bc034ca2a57720da7a63e00927a8f1/Mage/Task/BuiltIn/Database/Phinx/RollbackTask.php)** : Will execute the Phinx [rollback](http://docs.phinx.org/en/latest/commands.html#the-rollback-command) command if rollbacking.

Options : 
- phinx_cmd: /path/to/phinx (can also be set in the general config)
- environment: development
- configuration: phinx.php
- parser: php
- target: 20120103083322 (can also be set at runtime in the CLI with phinx-target:20120103083322 argument) - if not provided, Phinx will only rollback the last migration.

**[database/phinx/migrate-or-rollback](https://github.com/jhuet/Magallanes/blob/ea15df9257bc034ca2a57720da7a63e00927a8f1/Mage/Task/BuiltIn/Database/Phinx/MigrateOrRollbackTask.php)** : More interesting maybe, will execute either [migrate](http://docs.phinx.org/en/latest/commands.html#the-migrate-command) or [rollback](http://docs.phinx.org/en/latest/commands.html#the-rollback-command) Phinx command depending on the Magallanes context. Pay attention that if you rollback a deployment that migrated 3 migration scripts at once, you will need to specify the correct migration target (probably at runtime) that includes the 3 migrations.

Options : 
- phinx_cmd: /path/to/phinx (can also be set in the general config)
- environment: development
- configuration: phinx.php
- parser: php
- target: 20120103083322 (can also be set at runtime in the CLI with phinx-target:20120103083322 argument)

**[database/phinx/status](https://github.com/jhuet/Magallanes/blob/ea15df9257bc034ca2a57720da7a63e00927a8f1/Mage/Task/BuiltIn/Database/Phinx/StatusTask.php)** : Will execute the [status](http://docs.phinx.org/en/latest/commands.html#the-status-command) Phinx command. This could come handy because everything printed to the CLI will end up in Mage logs. This could allow you to see if all migrations that you expected have actually been migrated. I personally execute it twice, before and after migration or rollback.

Options : 
- phinx_cmd: /path/to/phinx (can also be set in the general config)
- environment: development
- configuration: phinx.php
- parser: php
