### PR TITLE
Add "Dryrun" mode for Rsync strategy

### DIFF
--- a/Mage/Command/BuiltIn/DeployCommand.php
+++ b/Mage/Command/BuiltIn/DeployCommand.php
@@ -130,6 +130,24 @@ class DeployCommand extends AbstractCommand implements RequiresEnvironment
     }
 
     /**
+     * Launch a Dry run command for Rsync strategy
+     * Without others sub tasks.
+     */
+    public function dryRun()
+    {
+        if ($this->getConfig()->deployment('strategy') != 'rsync') {
+            Console::output('<red>Error : Dry-run task is only available when using Rsync strategy.</red>', 1, 1);
+            return 232;
+        }
+        else {
+            // Launch Pre-DryRun tasks.
+            $this->runNonDeploymentTasks(AbstractTask::STAGE_PRE_DRYRUN, $this->getConfig(), 'Pre-DryRun');
+            // Launch Deployment in dryrun mode (true).
+            $this->runDeploymentTasks(TRUE);
+        }
+    }
+
+    /**
      * Deploys the Application
      * @see \Mage\Command\AbstractCommand::run()
      */
@@ -151,6 +169,11 @@ class DeployCommand extends AbstractCommand implements RequiresEnvironment
             return 230;
         } else {
             touch(getcwd() . '/.mage/~working.lock');
+        }
+
+        // If we are in dry run only
+        if ($this->getConfig()->getParameter('dry-run') === true) {
+            return $this->dryRun();
         }
 
         // Release ID
@@ -229,7 +252,7 @@ class DeployCommand extends AbstractCommand implements RequiresEnvironment
         if (self::$deployStatus === self::FAILED) {
             $exitCode = 1;
         }
-        
+
         return $exitCode;
     }
 
@@ -306,7 +329,7 @@ class DeployCommand extends AbstractCommand implements RequiresEnvironment
         }
     }
 
-    protected function runDeploymentTasks()
+    protected function runDeploymentTasks($dryrun = false)
     {
         if (self::$deployStatus == self::FAILED) {
             return;
@@ -340,7 +363,11 @@ class DeployCommand extends AbstractCommand implements RequiresEnvironment
 
                 Console::output('Deploying to <bold>' . $this->getConfig()->getHost() . '</bold>');
 
-                $tasksToRun = $this->getConfig()->getTasks();
+                $tasksToRun = array();
+
+                if ($dryrun !== false) {
+                    $tasksToRun = $this->getConfig()->getTasks();
+                }
 
                 $deployStrategy = $this->chooseDeployStrategy();
 
@@ -382,7 +409,7 @@ class DeployCommand extends AbstractCommand implements RequiresEnvironment
             }
 
             // Releasing
-            if (self::$deployStatus == self::SUCCEDED && $this->getConfig()->release('enabled', false) === true) {
+            if (self::$deployStatus == self::SUCCEDED && $dryrun !== true && $this->getConfig()->release('enabled', false) === true) {
                 // Execute the Releases
                 Console::output('Starting the <bold>Releasing</bold>');
                 $completedTasks = 0;
@@ -522,7 +549,6 @@ class DeployCommand extends AbstractCommand implements RequiresEnvironment
         if ($runTask === true) {
             try {
                 $result = $task->run();
-
                 if ($result === true) {
                     Console::output('<green>OK</green>', 0);
                     $result = true;

--- a/Mage/Task/AbstractTask.php
+++ b/Mage/Task/AbstractTask.php
@@ -29,6 +29,12 @@ abstract class AbstractTask
     const STAGE_PRE_DEPLOY = 'pre-deploy';
 
     /**
+     * Stage Constant for Pre Dry-Run
+     * @var string
+     */
+    const STAGE_PRE_DRYRUN = 'pre-dryrun';
+
+    /**
      * Stage Constant for Deployment
      * @var string
      */

--- a/Mage/Task/BuiltIn/Releases/ListTask.php
+++ b/Mage/Task/BuiltIn/Releases/ListTask.php
@@ -45,9 +45,7 @@ class ListTask extends AbstractTask implements IsReleaseAware
             $releases = ($output == '') ? array() : explode(PHP_EOL, $output);
 
             // Get Current
-            $result = $this->runCommandRemote('ls -l ' . $symlink, $output) && $result;
-            $currentRelease = explode('/', $output);
-            $currentRelease = trim(array_pop($currentRelease));
+            $currentRelease = $this->getCurrentRelease();
 
             if (count($releases) == 0) {
                 Console::output('<bold>No releases available</bold> ... ', 2);
@@ -90,6 +88,18 @@ class ListTask extends AbstractTask implements IsReleaseAware
             Console::output('');
             return false;
         }
+    }
+
+    /**
+     * Get the latest release.
+     */
+    public function getCurrentRelease()
+    {
+        $symlink = $this->getConfig()->release('symlink', 'current');
+        $this->runCommandRemote('ls -l ' . $symlink, $output);
+        $currentRelease = explode('/', $output);
+        $currentRelease = trim(array_pop($currentRelease));
+        return $currentRelease;
     }
 
     /**

--- a/docs/commands.txt
+++ b/docs/commands.txt
@@ -30,6 +30,9 @@ mage deploy to:production
 # Deploys Application to Production environment, overriding the current release
 mage deploy to:production --overrideRelease
 
+# Don't deploy application, only output the files to be deployed (works with Rsync strategy only).
+mage deploy to:production --dry-run
+
 # Locks deployment to Production environment
 mage lock to:production
 

--- a/docs/example-config/.mage/config/environment/production.yml
+++ b/docs/example-config/.mage/config/environment/production.yml
@@ -14,6 +14,8 @@ hosts:
   - s01.example.com
   - s02.example.com
 tasks:
+  pre-dryrun:
+#    - grunt
   pre-deploy:
     - scm/update
   on-deploy:

--- a/docs/example-config/.mage/config/environment/staging.yml
+++ b/docs/example-config/.mage/config/environment/staging.yml
@@ -14,6 +14,8 @@ hosts:
   - localhost
   - 127.0.0.1
 tasks:
+  pre-dryrun:
+#    - grunt
   pre-deploy:
 #    - sampleTask
 #    - failTask


### PR DESCRIPTION
# Dry-run mode with Rsync strategy

Sometimes it's useful to list the files to deploy without deploy you application. That's why "dry-run" mode is here.
### How to use it ?

You just to had a "dry-run" parameter to your deploy command like this : 

```
mage deploy to:production --dry-run
```
### How about "pre" and "post" deploy tasks ?

When using dry-run, all defined tasks are skipped : 
- Pre Deploy
- On Deploy
- Post Release
- Post Deploy

But you now have a new option called "pre-dryrun" in your environment conf file where you can add all tasks before dry-run is launched.

```
tasks:
  pre-deploy:
  pre-dryrun:
  on-deploy:
  post-release:
  post-deploy:
```

Related issue : 
https://github.com/andres-montanez/Magallanes/issues/39
