### PR TITLE
Issue #245 remove illegal option from mv command

### DIFF
--- a/Mage/Task/BuiltIn/Deployment/ReleaseTask.php
+++ b/Mage/Task/BuiltIn/Deployment/ReleaseTask.php
@@ -90,7 +90,7 @@ class ReleaseTask extends AbstractTask implements IsReleaseAware, SkipOnOverride
             if ($resultFetch && $userGroup != '') {
                 $command.= " && chown -h {$userGroup} {$tmplink}";
             }
-            $command.= " && mv -fT {$tmplink} {$symlink}";
+            $command.= " && mv -f {$tmplink} {$symlink}";
             $result = $this->runCommandRemote($command);
 
             if ($result) {


### PR DESCRIPTION
On FreeBSD the `-T` option for the `mv` command is not available. Therefore removed.