### PR TITLE
292: Notification email reports SUCCESS even if deployment failed

### DIFF
--- a/Mage/Command/BuiltIn/DeployCommand.php
+++ b/Mage/Command/BuiltIn/DeployCommand.php
@@ -215,7 +215,7 @@ class DeployCommand extends AbstractCommand implements RequiresEnvironment
         Console::output('Total time: <bold>' . $timeText . '</bold>.', 1, 2);
 
         // Send Notifications
-        $this->sendNotification(self::$failedTasks > 0 ? false : true);
+        $this->sendNotification(self::$deployStatus === self::SUCCEDED);
 
         // Unlock
         if (file_exists(getcwd() . '/.mage/~working.lock')) {


### PR DESCRIPTION
Fixing the bug reported in #292
