### PR TITLE
New options for e-mail notifications (BCC and CC)

### DIFF
--- a/Mage/Command/BuiltIn/DeployCommand.php
+++ b/Mage/Command/BuiltIn/DeployCommand.php
@@ -225,11 +225,11 @@ class DeployCommand extends AbstractCommand implements RequiresEnvironment
         if (self::$failedTasks === 0) {
             $exitCode = 0;
         }
-        
+
         if (self::$deployStatus === self::FAILED) {
             $exitCode = 1;
         }
-        
+
         return $exitCode;
     }
 
@@ -590,6 +590,8 @@ class DeployCommand extends AbstractCommand implements RequiresEnvironment
         $projectName = $this->getConfig()->general('name', false);
         $projectEmail = $this->getConfig()->general('email', false);
         $notificationsEnabled = $this->getConfig()->general('notifications', false);
+        $ccEmail = $this->getConfig()->general('email_options.cc', null);
+        $bccEmail = $this->getConfig()->general('email_options.bcc', null);
 
         // We need notifications enabled, and a project name and email to send the notification
         if (!$projectName || !$projectEmail || !$notificationsEnabled) {
@@ -600,8 +602,17 @@ class DeployCommand extends AbstractCommand implements RequiresEnvironment
         $mailer->setAddress($projectEmail)
             ->setProject($projectName)
             ->setLogFile(Console::getLogFile())
-            ->setEnvironment($this->getConfig()->getEnvironment())
-            ->send($result);
+            ->setEnvironment($this->getConfig()->getEnvironment());
+
+        if ($ccEmail) {
+            $mailer->setCc($ccEmail);
+        }
+
+        if ($bccEmail) {
+            $mailer->setBcc($bccEmail);
+        }
+
+        $mailer->send($result);
 
         return true;
     }

--- a/Mage/Command/BuiltIn/DeployCommand.php
+++ b/Mage/Command/BuiltIn/DeployCommand.php
@@ -590,8 +590,7 @@ class DeployCommand extends AbstractCommand implements RequiresEnvironment
         $projectName = $this->getConfig()->general('name', false);
         $projectEmail = $this->getConfig()->general('email', false);
         $notificationsEnabled = $this->getConfig()->general('notifications', false);
-        $ccEmail = $this->getConfig()->general('email_options.cc', null);
-        $bccEmail = $this->getConfig()->general('email_options.bcc', null);
+        $emailOptions = $this->getConfig()->general('email_options', array());
 
         // We need notifications enabled, and a project name and email to send the notification
         if (!$projectName || !$projectEmail || !$notificationsEnabled) {
@@ -604,12 +603,12 @@ class DeployCommand extends AbstractCommand implements RequiresEnvironment
             ->setLogFile(Console::getLogFile())
             ->setEnvironment($this->getConfig()->getEnvironment());
 
-        if ($ccEmail) {
-            $mailer->setCc($ccEmail);
+        if (isset($emailOptions['cc'])) {
+            $mailer->setCc($emailOptions['cc']);
         }
 
-        if ($bccEmail) {
-            $mailer->setBcc($bccEmail);
+        if (isset($emailOptions['bcc'])) {
+            $mailer->setBcc($emailOptions['bcc']);
         }
 
         $mailer->send($result);

--- a/Mage/Command/BuiltIn/DeployCommand.php
+++ b/Mage/Command/BuiltIn/DeployCommand.php
@@ -215,7 +215,7 @@ class DeployCommand extends AbstractCommand implements RequiresEnvironment
         Console::output('Total time: <bold>' . $timeText . '</bold>.', 1, 2);
 
         // Send Notifications
-        $this->sendNotification(self::$failedTasks > 0 ? false : true);
+        $this->sendNotification(self::$failedTasks > 0 ? false : true, new Mailer());
 
         // Unlock
         if (file_exists(getcwd() . '/.mage/~working.lock')) {
@@ -583,9 +583,10 @@ class DeployCommand extends AbstractCommand implements RequiresEnvironment
     /**
      * Send Email Notification if enabled
      * @param boolean $result
+     * @param mixed $mailer
      * @return boolean
      */
-    protected function sendNotification($result)
+    protected function sendNotification($result, $mailer)
     {
         $projectName = $this->getConfig()->general('name', false);
         $projectEmail = $this->getConfig()->general('email', false);
@@ -597,7 +598,6 @@ class DeployCommand extends AbstractCommand implements RequiresEnvironment
             return false;
         }
 
-        $mailer = new Mailer;
         $mailer->setAddress($projectEmail)
             ->setProject($projectName)
             ->setLogFile(Console::getLogFile())

--- a/Mage/Mailer.php
+++ b/Mage/Mailer.php
@@ -14,6 +14,7 @@ namespace Mage;
  * Mailer Helper.
  *
  * @author Andrés Montañez <andres@andresmontanez.com>
+ * @author César Suárez <suarez.ortega.cesar@gmail.com>
  */
 class Mailer
 {
@@ -24,6 +25,8 @@ class Mailer
     protected $project;
     protected $environment;
     protected $logFile;
+    protected $cc;
+    protected $bcc;
 
     public function setAddress($address)
     {
@@ -49,6 +52,18 @@ class Mailer
         return $this;
     }
 
+    public function setBcc($bcc)
+    {
+        $this->bcc = $bcc;
+        return $this;
+    }
+
+    public function setCc($cc)
+    {
+        $this->cc = $cc;
+        return $this;
+    }
+
     public function send($result)
     {
         $boundary = md5(date('r', time()));
@@ -60,6 +75,14 @@ class Mailer
             . 'MIME-Version: 1.0'
             . self::EOL
             . 'Content-Type: multipart/mixed; boundary=Mage-mixed-' . $boundary;
+
+        if ($this->cc) {
+            $headers .= self::EOL . 'Cc: ' . $this->cc;
+        }
+
+        if ($this->bcc) {
+            $headers .= self::EOL . 'Bcc: ' . $this->bcc;
+        }
 
         $subject = str_replace(
             array('{project}', '{environment}', '{result}'),

--- a/Mage/Mailer.php
+++ b/Mage/Mailer.php
@@ -106,6 +106,6 @@ class Mailer
             . $attachment . self::EOL
             . '--Mage-mixed-' . $boundary . '--' . self::EOL;
 
-        mail($this->address, $subject, $message, $headers);
+        return mail($this->address, $subject, $message, $headers);
     }
 }

--- a/tests/MageTest/Command/BuiltIn/DeployCommandTest.php
+++ b/tests/MageTest/Command/BuiltIn/DeployCommandTest.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace MageTest\Command\BuiltIn;
+
+use Mage\Command\BuiltIn\DeployCommand;
+use MageTest\TestHelper\BaseTest;
+use malkusch\phpmock\MockBuilder;
+
+/**
+ * Class DeployCommandTest
+ * @package MageTest\Command\BuiltIn
+ * @coversDefaultClass Mage\Command\BuiltIn\DeployCommand
+ * @uses malkusch\phpmock\MockBuilder
+ * @uses malkusch\phpmock\Mock
+ */
+class DeployCommandTest extends BaseTest
+{
+    /**
+     * @var DeployCommand
+     */
+    private $deployCommand;
+
+    /**
+     * @covers ::__construct
+     * @covers ::sendNotification
+     */
+    public function testSendRegularNotification()
+    {
+        $mailerMock = $this->getMock('Mage\Mailer');
+        $mailerMock
+            ->method('setAddress')
+            ->willReturnSelf();
+
+        $mailerMock
+            ->method('setProject')
+            ->willReturnSelf();
+
+        $mailerMock
+            ->method('setLogFile')
+            ->willReturnSelf();
+
+        $mailerMock
+            ->method('setEnvironment')
+            ->willReturnSelf();
+
+        $mailerMock
+            ->expects($this->once())
+            ->method('send');
+
+        $configMock = $this->getMock('Mage\Config');
+        $configMock
+            ->method('general')
+            ->willReturn(true);
+
+        $deployCommand = new DeployCommand();
+        $deployCommand->setConfig($configMock);
+
+        $this->callMethod(
+            $deployCommand,
+            'sendNotification',
+            array(true, $mailerMock));
+    }
+
+    public function testIgnoreNotification()
+    {
+        $mailerMock = $this->getMock('Mage\Mailer');
+
+        $mailerMock
+            ->expects($this->never())
+            ->method('send');
+
+        $configMock = $this->getMock('Mage\Config');
+        $configMock
+            ->method('general')
+            ->willReturn(false);
+
+        $deployCommand = new DeployCommand();
+        $deployCommand->setConfig($configMock);
+        $this->callMethod($deployCommand, 'sendNotification', array(true, $mailerMock));
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::sendNotification
+     */
+    public function testSendNotificationWithEmailOptions()
+    {
+        $mailerMock = $this->getMock('Mage\Mailer');
+        $mailerMock
+            ->method('setAddress')
+            ->willReturnSelf();
+
+        $mailerMock
+            ->method('setProject')
+            ->willReturnSelf();
+
+        $mailerMock
+            ->method('setLogFile')
+            ->willReturnSelf();
+
+        $mailerMock
+            ->method('setEnvironment')
+            ->willReturnSelf();
+
+        $mailerMock
+            ->expects($this->once())
+            ->method('setCc')
+            ->willReturnSelf();
+
+        $mailerMock
+            ->expects($this->once())
+            ->method('setBcc')
+            ->willReturnSelf();
+
+        $mailerMock
+            ->expects($this->once())
+            ->method('send');
+
+        $configMock = $this->getMock('Mage\Config');
+
+        $configMock
+            ->method('general')
+            ->will($this->returnCallback(function($option, $default) {
+                if (strcmp($option, 'email_options') === 0) {
+                    return array('bcc' => true, 'cc' => true);
+                }
+                return true;
+            }));
+
+        $deployCommand = new DeployCommand();
+        $deployCommand->setConfig($configMock);
+
+        $this->callMethod(
+            $deployCommand,
+            'sendNotification',
+            array(true, $mailerMock));
+    }
+}

--- a/tests/MageTest/Command/BuiltIn/DeployCommandTest.php
+++ b/tests/MageTest/Command/BuiltIn/DeployCommandTest.php
@@ -9,6 +9,8 @@ use MageTest\TestHelper\BaseTest;
  * Class DeployCommandTest
  * @package MageTest\Command\BuiltIn
  * @coversDefaultClass Mage\Command\BuiltIn\DeployCommand
+ * @uses Mage\Console
+ * @uses Mage\Command\AbstractCommand
  */
 class DeployCommandTest extends BaseTest
 {

--- a/tests/MageTest/Command/BuiltIn/DeployCommandTest.php
+++ b/tests/MageTest/Command/BuiltIn/DeployCommandTest.php
@@ -4,14 +4,11 @@ namespace MageTest\Command\BuiltIn;
 
 use Mage\Command\BuiltIn\DeployCommand;
 use MageTest\TestHelper\BaseTest;
-use malkusch\phpmock\MockBuilder;
 
 /**
  * Class DeployCommandTest
  * @package MageTest\Command\BuiltIn
  * @coversDefaultClass Mage\Command\BuiltIn\DeployCommand
- * @uses malkusch\phpmock\MockBuilder
- * @uses malkusch\phpmock\Mock
  */
 class DeployCommandTest extends BaseTest
 {

--- a/tests/MageTest/Command/BuiltIn/DeployCommandTest.php
+++ b/tests/MageTest/Command/BuiltIn/DeployCommandTest.php
@@ -16,11 +16,6 @@ use malkusch\phpmock\MockBuilder;
 class DeployCommandTest extends BaseTest
 {
     /**
-     * @var DeployCommand
-     */
-    private $deployCommand;
-
-    /**
      * @covers ::__construct
      * @covers ::sendNotification
      */

--- a/tests/MageTest/MailerTest.php
+++ b/tests/MageTest/MailerTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace MageTest;
+
+use Mage\Mailer;
+use MageTest\TestHelper\BaseTest;
+use malkusch\phpmock\MockBuilder;
+
+/**
+ * Class MailerTest
+ * @package MageTest\Command\BuiltIn
+ * @coversDefaultClass Mage\Command\BuiltIn\DeployCommand
+ * @uses malkusch\phpmock\MockBuilder
+ * @uses malkusch\phpmock\Mock
+ */
+class MailerTest extends BaseTest
+{
+    /**
+     * @covers ::__construct
+     * @covers ::send
+     */
+    public function testRegularSend()
+    {
+
+        $mailExecuted = false;
+
+        $builder = new MockBuilder();
+        $mockMail = $builder
+            ->setNamespace('Mage')
+            ->setName('mail')
+            ->setFunction(
+                function () use ($mailExecuted){
+                    return true;
+                }
+            )
+            ->build();
+
+        $mockFileGetContents = $builder
+            ->setNamespace('Mage')
+            ->setName('file_get_contents')
+            ->setFunction(
+                function () {
+                    return true;
+                }
+            )
+            ->build();
+
+        $mockMail->enable();
+        $mockFileGetContents->enable();
+
+        $mailer = new Mailer();
+        $mailer->setLogFile('test');
+        $result = $mailer->send(true);
+
+        $this->assertTrue($result);
+
+        $mockMail->disable();
+        $mockFileGetContents->disable();
+
+    }
+}

--- a/tests/MageTest/MailerTest.php
+++ b/tests/MageTest/MailerTest.php
@@ -9,7 +9,7 @@ use malkusch\phpmock\MockBuilder;
 /**
  * Class MailerTest
  * @package MageTest\Command\BuiltIn
- * @coversDefaultClass Mage\Command\BuiltIn\DeployCommand
+ * @coversDefaultClass Mage\Mailer
  * @uses malkusch\phpmock\MockBuilder
  * @uses malkusch\phpmock\Mock
  */

--- a/tests/MageTest/MailerTest.php
+++ b/tests/MageTest/MailerTest.php
@@ -11,12 +11,14 @@ use malkusch\phpmock\MockBuilder;
  * @package MageTest\Command\BuiltIn
  * @coversDefaultClass Mage\Mailer
  * @uses Mage\Console
+ * @uses malkusch\phpmock\Mock
  * @uses malkusch\phpmock\MockBuilder
  */
 class MailerTest extends BaseTest
 {
     /**
      * @covers ::send
+     * @covers ::setLogFile
      */
     public function testRegularSend()
     {

--- a/tests/MageTest/MailerTest.php
+++ b/tests/MageTest/MailerTest.php
@@ -10,8 +10,8 @@ use malkusch\phpmock\MockBuilder;
  * Class MailerTest
  * @package MageTest\Command\BuiltIn
  * @coversDefaultClass Mage\Mailer
+ * @uses Mage\Console
  * @uses malkusch\phpmock\MockBuilder
- * @uses malkusch\phpmock\Mock
  */
 class MailerTest extends BaseTest
 {

--- a/tests/MageTest/MailerTest.php
+++ b/tests/MageTest/MailerTest.php
@@ -16,7 +16,6 @@ use malkusch\phpmock\MockBuilder;
 class MailerTest extends BaseTest
 {
     /**
-     * @covers ::__construct
      * @covers ::send
      */
     public function testRegularSend()

--- a/tests/MageTest/TestHelper/BaseTest.php
+++ b/tests/MageTest/TestHelper/BaseTest.php
@@ -11,6 +11,7 @@ namespace MageTest\TestHelper;
  *
  * @package MageTest\TestHelper
  * @author Jakub Turek <ja@kubaturek.pl>
+ * @author César Suárez <suarez.ortega.cesar@gmail.com>
  */
 abstract class BaseTest extends \PHPUnit_Framework_TestCase
 {
@@ -41,6 +42,20 @@ abstract class BaseTest extends \PHPUnit_Framework_TestCase
         $configProperty = new \ReflectionProperty($object, $propertyName);
         $configProperty->setAccessible(true);
         $configProperty->setValue($object, $value);
+    }
+
+    /**
+     * Calls a protected/private methord
+     * @param  object $object Object instance
+     * @param  string $methodName Name of the method
+     * @param  array  $args Arguments for the method
+     * @return mixed The output of the method
+     */
+    final protected static function callMethod($object, $methodName, array $args) {
+        $class = new \ReflectionClass($object);
+        $method = $class->getMethod($methodName);
+        $method->setAccessible(true);
+        return $method->invokeArgs($object, $args);
     }
 
     /**


### PR DESCRIPTION
Hello,

I have added a new feature which ables to define Bcc and Cc parameters for e-mail notifications. It can be used in the following way:

``` yml
#general.yml

email_options:
  bcc: foo@bar.com
  cc: foo2@bar.com
```

I hope you can find it useful :)

Regards

**NOTE:** Related issues: #252 
