### PR TITLE
Enable to configure strict host key checking [closes #105]

### DIFF
--- a/Mage/Config.php
+++ b/Mage/Config.php
@@ -389,6 +389,16 @@ class Config
     }
 
     /**
+     * Get UserKnownHostsFile & StrictHostKeyChecking options
+     *
+     * @return string
+     */
+    public function getStrictHostCheckingOption()
+    {
+        return $this->general('ssh-strict-host-key-checking', true) ? '' : ' -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ';
+    }
+
+    /**
      * Get the ConnectTimeout option
      *
      * @return string

--- a/Mage/Task/AbstractTask.php
+++ b/Mage/Task/AbstractTask.php
@@ -197,7 +197,7 @@ abstract class AbstractTask
         $needs_tty = ($this->getConfig()->general('ssh_needs_tty', false) ? '-t' : '');
 
         $localCommand = 'ssh ' . $this->getConfig()->getHostIdentityFileOption() . $needs_tty . ' -p ' . $this->getConfig()->getHostPort() . ' '
-            . '-q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no '
+            . $this->getConfig()->getStrictHostCheckingOption()
             . $this->getConfig()->getConnectTimeoutOption()
             . ($this->getConfig()->deployment('user') != '' ? $this->getConfig()->deployment('user') . '@' : '')
             . $this->getConfig()->getHostName();

--- a/Mage/Task/BuiltIn/Deployment/Strategy/TarGzTask.php
+++ b/Mage/Task/BuiltIn/Deployment/Strategy/TarGzTask.php
@@ -95,7 +95,7 @@ class TarGzTask extends BaseStrategyTaskAbstract implements IsReleaseAware
         // Copy Tar Gz  to Remote Host
         $command = 'scp ' . $strategyFlags . ' ' . $this->getConfig()->getHostIdentityFileOption()
             . $this->getConfig()->getConnectTimeoutOption() . '-P ' . $this->getConfig()->getHostPort()
-            . " -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no "
+            . $this->getConfig()->getStrictHostCheckingOption()
             . ' ' . $localTarGz . '.tar.gz '
             . $this->getConfig()->deployment('user') . '@' . $this->getConfig()->getHostName() . ':'
             . $deployToDirectory;


### PR DESCRIPTION
Software should be secure by default, so the default option is to enable
strict host key checking. When lowering security, the user should be
aware of it and it should be his choice.
