### PR TITLE
Update PHP version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "type": "library",
     "keywords": ["deployment"],
     "require": {
-        "php": ">=5.3"
+        "php": ">=5.4"
     },
     "require-dev": {
         "phpunit/phpunit": "4.3.5",


### PR DESCRIPTION
Using short array syntax is allowed in PHP 5.4 only:
https://github.com/andres-montanez/Magallanes/blob/master/Mage/Task/BuiltIn/Filesystem/ApplyFaclsTask.php#L36