### PR TITLE
Detect and remove "Identity added:" line from the remote server.

### DIFF
--- a/Mage/Task/BuiltIn/Deployment/ReleaseTask.php
+++ b/Mage/Task/BuiltIn/Deployment/ReleaseTask.php
@@ -61,6 +61,26 @@ class ReleaseTask extends AbstractTask implements IsReleaseAware, SkipOnOverride
                 // and awk parameters need special care depending on the executing shell
                 $resultFetch = $this->runCommandRemote("ls -ld .", $directoryInfos);
                 if (!empty($directoryInfos)) {
+
+
+                    // break $directoryInfos by line break
+                    // to exclude unwanted line(s)
+                    $lines = explode("\n", $directoryInfos);
+                    $filtered_lines = array();
+                    foreach ($lines as $line) {
+
+                        // exclude line that starts with 'Identity added'
+                        // e.g.: from ssh with ProxyCommand / proxy jump
+                        if (stripos($line, "Identity added") !== FALSE) {
+                            continue;
+                        }
+
+                        $filtered_lines[] = $line;
+                    }
+                    // reconstruct $directoryInfos using the filtered lines
+                    $directoryInfos = implode("\n", $filtered_lines);
+
+
                     //uniformize format as it depends on the system deployed on
                     $directoryInfos = trim(str_replace(array("  ", "\t"), ' ', $directoryInfos));
                     $infoArray = explode(' ', $directoryInfos);


### PR DESCRIPTION
Sometimes remote command "ls -ld ." returns unwanted line(s). In my case it was returning "Identity added..." which is caused by ProxyCommand config (which I need in my environment). I've added some codes to detect and remove this.

Example from log that illustrate the issue:

2016-12-26 05:45:01 -- ---------------------------------
2016-12-26 05:45:01 -- ---- Executing: $ ssh  -p 22 -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no user@host "sh -c \"cd /path/to/dir && ls -ld .\""
2016-12-26 05:45:05 -- Identity added: /home/user123/.ssh/id_rsa (/home/user123/.ssh/id_rsa)
drwxr-xr-x 6 deployuser deployuser 4096 Dec 26 18:33 .
2016-12-26 05:45:05 -- ---------------------------------

The output from remote server was:

Identity added: /home/user123/.ssh/id_rsa (/home/user123/.ssh/id_rsa)
drwxr-xr-x 6 deployuser deployuser 4096 Dec 26 18:33 .

We don't want the first line above that starts with 'Identity added'