### PR TITLE
WIP: Added support for Phar building with Box2

### DIFF
--- a/bin/mage
+++ b/bin/mage
@@ -11,7 +11,7 @@ if (file_exists(__DIR__ . '/../../../autoload.php')) {
 use Mage\MageApplication;
 
 try {
-    $mage = new MageApplication('.mage.yml');
+    $mage = new MageApplication(getcwd().DIRECTORY_SEPARATOR.'.mage.yml');
     $mage->run();
 } catch (Exception $exception) {
     printf('Error: %s' . PHP_EOL, $exception->getMessage());

--- a/box.json.dist
+++ b/box.json.dist
@@ -1,0 +1,25 @@
+{
+  "chmod": "0755",
+  "compression": "GZ",
+  "directories": [
+    "src"
+  ],
+  "files": [
+    "LICENSE"
+  ],
+  "finder": [
+    {
+      "name": "*.php",
+      "exclude": [
+        "tests",
+        "test"
+      ],
+      "in": "vendor"
+    }
+  ],
+  "git-version": "package_version",
+  "intercept": true,
+  "main": "bin/mage",
+  "output": "mage.phar",
+  "stub": true
+}

--- a/src/MageApplication.php
+++ b/src/MageApplication.php
@@ -78,12 +78,16 @@ class MageApplication extends Application
 
         if (array_key_exists('magephp', $config) && is_array($config['magephp'])) {
             $logger = null;
-            if (array_key_exists('log_dir', $config['magephp']) && file_exists($config['magephp']['log_dir']) && is_dir($config['magephp']['log_dir'])) {
-                $logfile = sprintf('%s/%s.log', $config['magephp']['log_dir'], date('Ymd_His'));
-                $config['magephp']['log_file'] = $logfile;
+            if (array_key_exists('log_dir', $config['magephp'])) {
+                $logDirectory = realpath($config['magephp']['log_dir']);
 
-                $logger = new Logger('magephp');
-                $logger->pushHandler(new StreamHandler($logfile));
+                if (file_exists($logDirectory) && is_dir($logDirectory)) {
+                    $logfile = sprintf('%s/%s.log', $logDirectory, date('Ymd_His'));
+                    $config['magephp']['log_file'] = $logfile;
+
+                    $logger = new Logger('magephp');
+                    $logger->pushHandler(new StreamHandler($logfile));
+                }
             }
 
             $this->runtime->setConfiguration($config['magephp']);


### PR DESCRIPTION
See #337: How to create the `mage.phar` executable:

-  Download Box2
  `curl -LSs https://box-project.github.io/box2/installer.php | php`
- Get mage dependencies, with no -dev requirements: 
  `composer install --no-dev`
- Build `Mage.phar`
  `./box.phar build`

Todo:
- [x] Create box.dist.json file
- [ ] Update travis.yml to build phar files on tags
- [ ] Update travis.yml to deploy the new artifact with the tagged release
- [ ] Include Signed OpenSSH phar (see https://mwop.net/blog/2015-12-14-secure-phar-automation.html)