### PR TITLE
Rsync task: ignore empty 'exclude' parameters

### DIFF
--- a/src/Task/BuiltIn/Deploy/RsyncTask.php
+++ b/src/Task/BuiltIn/Deploy/RsyncTask.php
@@ -55,7 +55,7 @@ class RsyncTask extends AbstractTask
     protected function getExcludes()
     {
         $excludes = $this->runtime->getEnvOption('exclude', []);
-        $excludes = array_merge(['.git'], $excludes);
+        $excludes = array_merge(['.git'], array_filter($excludes));
 
         foreach ($excludes as &$exclude) {
             $exclude = '--exclude=' . $exclude;

--- a/src/Task/BuiltIn/Deploy/Tar/PrepareTask.php
+++ b/src/Task/BuiltIn/Deploy/Tar/PrepareTask.php
@@ -52,7 +52,7 @@ class PrepareTask extends AbstractTask
     protected function getExcludes()
     {
         $excludes = $this->runtime->getEnvOption('exclude', []);
-        $excludes = array_merge(['.git'], $excludes);
+        $excludes = array_merge(['.git'], array_filter($excludes));
 
         foreach ($excludes as &$exclude) {
             $exclude = '--exclude="' . $exclude . '"';


### PR DESCRIPTION
When empty lines are left in the "exclude" list, RSync is still sending `--eclude=` with empty excluded items