### PR TITLE
[#336] Implementation system execute

### DIFF
--- a/src/Task/BuiltIn/System/AbstractSystemTask.php
+++ b/src/Task/BuiltIn/System/AbstractSystemTask.php
@@ -1,0 +1,106 @@
+<?php
+/*
+ * This file is part of the Magallanes package.
+ *
+ * (c) Halis Duraki <duraki.halis@nsoft.ba>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mage\Task\BuiltIn\System;
+
+use Mage\Task\Exception\ErrorException;
+use Mage\Task\AbstractTask;
+
+/**
+ * System Kernel Task - Abstract Base class for System Operations
+ *
+ * @author Halis Duraki <duraki.halis@nsoft.ba>
+ */
+abstract class AbstractSystemTask extends AbstractTask
+{
+    /**
+     * Returns the Task options
+     *
+     * @return array
+     * @throws ErrorException
+     */
+    protected function getOptions()
+    {
+        $mandatory = $this->getParameters();
+
+        foreach ($mandatory as $parameter) {
+            if (!array_key_exists($parameter, $this->options)) {
+                throw new ErrorException(sprintf('Parameter "%s" is not defined', $parameter));
+            }
+        }
+
+        return $this->options;
+    }
+
+    /**
+     * Returns the mandatory parameters
+     *
+     * @return array
+     */
+    abstract protected function getParameters();
+
+    /**
+     * Returns command with the placeholders replaced
+     *
+     * @param  string $command 
+     * @return string          
+     * @throws ErrorException 
+     */
+    protected function getCommand($command)
+    {
+        $mapping = [
+            '%environment%' => $this->runtime->getEnvironment(),
+        ];
+
+        if ($this->runtime->getWorkingHost() !== null) {
+            $mapping['%host%'] = $this->runtime->getWorkingHost();
+        }
+
+        if ($this->runtime->getReleaseId() !== null) {
+            $mapping['%release%'] = $this->runtime->getReleaseId();
+        }
+
+        $options = $this->getOptions();
+        return str_replace(
+            array_keys($mapping),
+            array_values($mapping),
+            $options[$command]
+        );
+    }
+
+    /**
+     * Returns a file with the placeholders replaced
+     *
+     * @param string $file
+     * @return string
+     * @throws ErrorException
+     */
+    protected function getFile($file)
+    {
+        $mapping = [
+            '%environment%' => $this->runtime->getEnvironment(),
+        ];
+
+        if ($this->runtime->getWorkingHost() !== null) {
+            $mapping['%host%'] = $this->runtime->getWorkingHost();
+        }
+
+        if ($this->runtime->getReleaseId() !== null) {
+            $mapping['%release%'] = $this->runtime->getReleaseId();
+        }
+
+        $options = $this->getOptions();
+        return str_replace(
+            array_keys($mapping),
+            array_values($mapping),
+            $options[$file]
+        );
+    }
+}

--- a/src/Task/BuiltIn/System/AbstractSystemTask.php
+++ b/src/Task/BuiltIn/System/AbstractSystemTask.php
@@ -75,32 +75,4 @@ abstract class AbstractSystemTask extends AbstractTask
         );
     }
 
-    /**
-     * Returns a file with the placeholders replaced
-     *
-     * @param string $file
-     * @return string
-     * @throws ErrorException
-     */
-    protected function getFile($file)
-    {
-        $mapping = [
-            '%environment%' => $this->runtime->getEnvironment(),
-        ];
-
-        if ($this->runtime->getWorkingHost() !== null) {
-            $mapping['%host%'] = $this->runtime->getWorkingHost();
-        }
-
-        if ($this->runtime->getReleaseId() !== null) {
-            $mapping['%release%'] = $this->runtime->getReleaseId();
-        }
-
-        $options = $this->getOptions();
-        return str_replace(
-            array_keys($mapping),
-            array_values($mapping),
-            $options[$file]
-        );
-    }
 }

--- a/src/Task/BuiltIn/System/Exec/ExecuteSystem.php
+++ b/src/Task/BuiltIn/System/Exec/ExecuteSystem.php
@@ -1,0 +1,55 @@
+<?php
+/*
+ * This file is part of the Magallanes package.
+ *
+ * (c) Halis Duraki <duraki.halis@nsoft.ba>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mage\Task\BuiltIn\System\Exec;
+
+use Mage\Task\BuiltIn\System\AbstractSystemTask;
+use Symfony\Component\Process\Process;
+use Exception;
+
+/**
+ * System Task - Execute a system command
+ *
+ * @author Halis Duraki <duraki.halis@nsoft.ba>
+ */
+class ExecuteSystem extends AbstractSystemTask
+{
+    public function getName()
+    {
+        return 'system/exec';
+    }
+
+    public function getDescription()
+    {
+        try {
+            return sprintf('[SYSTEM] Execute "%s" on system level', $this->getCommand('exec'));
+        } catch (Exception $exception) {
+            return '[SYSTEM] Exec [missing parameters]';
+        }
+    }
+
+    public function execute()
+    {
+        $execCommand = $this->getCommand('exec');
+        $execArgument = $this->getCommand('arg');
+
+        $cmd = sprintf("$execCommand $execArgument");
+
+        /** @var Process $process */
+        $process = $this->runtime->runCommand($cmd);
+
+        return $process->isSuccessful();
+    }
+
+    protected function getParameters()
+    {
+        return ['exec', 'arg'];
+    }
+}

--- a/tests/Task/BuiltIn/SystemKernelTaskTest.php
+++ b/tests/Task/BuiltIn/SystemKernelTaskTest.php
@@ -1,0 +1,50 @@
+<?php
+/*
+ * This file is part of the Magallanes package.
+ *
+ * (c) Halis Duraki <duraki.halis@nsoft.ba>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mage\Tests\Task\BuiltIn;
+
+use Mage\Task\Exception\ErrorException;
+use Mage\Task\BuiltIn\System\Exec\ExecuteSystem;
+use Exception;
+use Mage\Tests\Runtime\RuntimeMockup;
+use PHPUnit_Framework_TestCase as TestCase;
+
+class SystemKernelTaskTest extends TestCase
+{
+
+    public function testExecuteSystem()
+    {
+        $runtime = new RuntimeMockup();
+        $runtime->setConfiguration(['environments' => ['test' => []]]);
+        $runtime->setEnvironment('test');
+
+        $exec = new ExecuteSystem();
+        $exec->setOptions(['exec' => 'cat', 'arg' => '/etc/passwd']);
+        $exec->setRuntime($runtime);
+
+        $this->assertContains('cat', $exec->getDescription());
+        $exec->execute();
+
+        $ranCommands = $runtime->getRanCommands();
+
+        $testCase = array(
+            0 => 'cat /etc/passwd',
+        );
+
+        // Check total of Executed Commands
+        $this->assertEquals(count($testCase), count($ranCommands));
+
+        // Check Generated Commands
+        foreach ($testCase as $index => $command) {
+            $this->assertEquals($command, $ranCommands[$index]);
+        }
+    }
+
+}


### PR DESCRIPTION
As written in #336 I'm sending a pull request with equivalent `action`, a base model for execution of file through configuration file, rather then writing new task for specific execution.

The bundle is called `System`, since in the near future I'd implement a various ops-based scenarios, as an example of these are: **Get uptime**, **Get environment**, **Return kernel version**, **Execute** etc. 
  
Usage is fairly simple as this is built-in task.

The task expect two parameters:
* `exec` - The program/command you are planning to execute
* `arg` - A program execution arguments

Example of usage (will restart all supervisor jobs @ on-deploy phase):

```magephp:
    environments:
        production:
            on-deploy:
                - system/exec: { exec: 'supervisorctl', arg: 'restart all' }```
