### PR TITLE
Added task to execute arbitrary commands

### DIFF
--- a/src/Task/BuiltIn/ExecTask.php
+++ b/src/Task/BuiltIn/ExecTask.php
@@ -1,0 +1,84 @@
+<?php
+/*
+ * This file is part of the Magallanes package.
+ *
+ * (c) Andrés Montañez <andres@andresmontanez.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mage\Task\BuiltIn;
+
+use Mage\Task\Exception\ErrorException;
+use Mage\Task\AbstractTask;
+
+/**
+ * Exec task. Allows you to execute arbitrary commands.
+ *
+ * @author Yanick Witschi <https://github.com/Toflar>
+ */
+class ExecTask extends AbstractTask
+{
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return 'exec';
+    }
+
+    /**
+     * @return string
+     */
+    public function getDescription()
+    {
+        $options = $this->getOptions();
+
+        if ('' !== $options['descr']) {
+            return (string) $options['descr'];
+        }
+
+        return '[Exec] Executing custom command';
+    }
+
+    /**
+     * @return bool
+     *
+     * @throws ErrorException
+     */
+    public function execute()
+    {
+        $options = $this->getOptions();
+
+        if ('' === $options['cmd']) {
+            throw new ErrorException('What about if you gave me a command to execute?');
+        }
+
+        // If not jailed, it must run as remote command
+        if (false === $options['jail']) {
+            $process = $this->runtime->runRemoteCommand($options['cmd'], false, $options['timeout']);
+            return $process->isSuccessful();
+        }
+
+        $process = $this->runtime->runCommand($options['cmd'], $options['timeout']);
+        return $process->isSuccessful();
+    }
+
+    /**
+     * @return array
+     */
+    protected function getOptions()
+    {
+        $options = array_merge([
+                'cmd' => '',
+                'descr' => '',
+                'jail' => true,
+                'timeout' => 120
+            ],
+            $this->options
+        );
+
+        return $options;
+    }
+}

--- a/tests/Command/BuiltIn/ExecTaskTest.php
+++ b/tests/Command/BuiltIn/ExecTaskTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Mage\Tests\Command\BuiltIn;
+
+use Mage\Runtime\Runtime;
+use Mage\Task\BuiltIn\ExecTask;
+use PHPUnit_Framework_TestCase as TestCase;
+use Symfony\Component\Process\Process;
+
+class ExecTaskTest extends TestCase
+{
+    public function testBasics()
+    {
+        $task = new ExecTask();
+        $this->assertSame('exec', $task->getName());
+        $this->assertSame('[Exec] Executing custom command', $task->getDescription());
+    }
+
+    public function testCustomDescription()
+    {
+        $task = new ExecTask();
+        $task->setOptions(['descr' => '[My project] This is my wonderful task']);
+        $this->assertSame('[My project] This is my wonderful task', $task->getDescription());
+    }
+
+    /**
+     * @expectedException \Mage\Task\Exception\ErrorException
+     */
+    public function testNoCommandProvided()
+    {
+        $task = new ExecTask();
+        $task->execute();
+    }
+
+    public function testNonJailedCommand()
+    {
+        $runtime = $this->getMockBuilder(Runtime::class)
+            ->setMethods(['runRemoteCommand'])
+            ->getMock();
+
+        $runtime
+            ->expects($this->once())
+            ->method('runRemoteCommand')
+            ->with('rm -rf /')
+            ->willReturn($this->mockProcess(true));
+
+
+        $task = $this->getTask($runtime);
+        $task->setOptions(['cmd' => 'rm -rf /', 'jail' => false]);
+        $this->assertTrue($task->execute());
+    }
+
+    public function testRegularCommand()
+    {
+        $runtime = $this->getMockBuilder(Runtime::class)
+            ->setMethods(['runCommand'])
+            ->getMock();
+
+        $runtime
+            ->expects($this->once())
+            ->method('runCommand')
+            ->with('rm -rf /', 10)
+            ->willReturn($this->mockProcess(true));
+
+        $task = $this->getTask($runtime);
+        $task->setOptions(['cmd' => 'rm -rf /', 'timeout' => 10]);
+        $task->execute();
+    }
+
+    private function getTask($runtime)
+    {
+        $task = new ExecTask();
+        $task->setRuntime($runtime);
+
+        return $task;
+    }
+
+    private function mockProcess($successful)
+    {
+        $process = $this->getMockBuilder(Process::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $process
+            ->expects($this->any())
+            ->method('isSuccessful')
+            ->willReturn($successful);
+
+        return $process;
+    }
+}


### PR DESCRIPTION
This is a PR for https://github.com/andres-montanez/Magallanes/issues/336.

Usage:

```yml
- exec { cmd: 'my command' }
```

If you like, you can pass a custom description like so:


```yml
- exec { cmd: 'my command', descr: 'My command does this and that' }
```

Also you can `jail` it (which forces remote execution) and adjust the `timeout`. 😎 