### PR TITLE
[FEATURE] allow exclude definition global

### DIFF
--- a/src/Task/BuiltIn/Deploy/RsyncTask.php
+++ b/src/Task/BuiltIn/Deploy/RsyncTask.php
@@ -54,7 +54,7 @@ class RsyncTask extends AbstractTask
 
     protected function getExcludes()
     {
-        $excludes = $this->runtime->getEnvOption('exclude', []);
+        $excludes = $this->runtime->getMergedOption('exclude', []);
         $excludes = array_merge(['.git'], array_filter($excludes));
 
         foreach ($excludes as &$exclude) {

--- a/src/Task/BuiltIn/Deploy/Tar/PrepareTask.php
+++ b/src/Task/BuiltIn/Deploy/Tar/PrepareTask.php
@@ -51,7 +51,7 @@ class PrepareTask extends AbstractTask
 
     protected function getExcludes()
     {
-        $excludes = $this->runtime->getEnvOption('exclude', []);
+        $excludes = $this->runtime->getMergedOption('exclude', []);
         $excludes = array_merge(['.git'], array_filter($excludes));
 
         foreach ($excludes as &$exclude) {

--- a/tests/Command/BuiltIn/DeployCommandMiscTasksTest.php
+++ b/tests/Command/BuiltIn/DeployCommandMiscTasksTest.php
@@ -50,9 +50,27 @@ class DeployCommandMiscTasksTest extends TestCase
         $this->assertEquals(0, $tester->getStatusCode());
     }
 
-    public function testComposerFlags()
+    public function composerFlagsDataProvider() {
+        return [
+            'default' => [
+                'yml' => __DIR__ . '/../../Resources/composer.yml'
+            ],
+            'global exclude' => [
+                'yml' => __DIR__ . '/../../Resources/global-exclude.yml'
+            ],
+        ];
+    }
+
+    /**
+     * testComposerFlags
+     *
+     * @dataProvider composerFlagsDataProvider
+     * @param string $yml
+     * @return void
+     */
+    public function testComposerFlags($yml)
     {
-        $application = new MageApplicationMockup(__DIR__ . '/../../Resources/composer.yml');
+        $application = new MageApplicationMockup($yml);
 
         /** @var AbstractCommand $command */
         $command = $application->find('deploy');

--- a/tests/Resources/global-exclude.yml
+++ b/tests/Resources/global-exclude.yml
@@ -1,0 +1,17 @@
+magephp:
+    log_dir: /tmp
+    composer:
+        path: /usr/bin/composer.phar
+    exclude:
+        - ./var/cache/*
+        - ./var/log/*
+        - ./web/app_dev.php
+    environments:
+        test:
+            user: tester
+            host_path: /var/www/test
+            hosts:
+                - testhost
+            pre-deploy:
+                - composer/install: { flags: '--prefer-source' }
+                - composer/dump-autoload: { flags: '--no-scripts' }


### PR DESCRIPTION
Hi,

I've allowed the exclude definition to be globally defined. My Configuration uses on every environment the same excludes and so i must implement duplicate code. With this feature i define the excludes only one time. 

Now its both possible global and environment specific

Example: tests/Resources/global-exclude.yml