### PR TITLE
[#361] Add tar_from parameter to deploy specific directories

### DIFF
--- a/src/Task/BuiltIn/Deploy/Tar/PrepareTask.php
+++ b/src/Task/BuiltIn/Deploy/Tar/PrepareTask.php
@@ -42,7 +42,8 @@ class PrepareTask extends AbstractTask
 
         $excludes = $this->getExcludes();
         $flags = $this->runtime->getEnvOption('tar_create', 'cfzp');
-        $cmdTar = sprintf('tar %s %s %s ./', $flags, $tarLocal, $excludes);
+        $from = $this->runtime->getEnvOption('tar_from', './');
+        $cmdTar = sprintf('tar %s %s %s %s', $flags, $tarLocal, $excludes, $from);
 
         /** @var Process $process */
         $process = $this->runtime->runLocalCommand($cmdTar, 300);


### PR DESCRIPTION
Equvalent 'from' parameter as in version 1 to deploy from a specific directory instead of the current root directory.

*Usage:*

```magephp:
    environments:
        development:
            tar_from: /directory/to/deploy
            [...]
```