### PR TITLE
[FEATURE] Added support for specifying task timeout in composer install task

### DIFF
--- a/src/Task/BuiltIn/Composer/InstallTask.php
+++ b/src/Task/BuiltIn/Composer/InstallTask.php
@@ -36,7 +36,7 @@ class InstallTask extends AbstractTask
         $cmd = sprintf('%s install %s', $options['path'], $options['flags']);
 
         /** @var Process $process */
-        $process = $this->runtime->runCommand(trim($cmd));
+        $process = $this->runtime->runCommand(trim($cmd), $options['timeout']);
 
         return $process->isSuccessful();
     }
@@ -44,7 +44,7 @@ class InstallTask extends AbstractTask
     protected function getOptions()
     {
         $options = array_merge(
-            ['path' => 'composer', 'flags' => '--optimize-autoloader'],
+            ['path' => 'composer', 'flags' => '--optimize-autoloader', 'timeout' => 120],
             $this->runtime->getMergedOption('composer'),
             $this->options
         );


### PR DESCRIPTION
It's not unusual, depending on your environment, for Composer's install command to exceed the default 120 second timeout value. This allows you to configure that value and keeps the default 120 second value otherwise.   
  
Usage:  
  
```
magephp:
  environments:
    production:
      pre-deploy:
        - composer/install: { timeout: 600 }
      [...]
```
