### PR TITLE
Increase timeout for Composer task

### DIFF
--- a/src/Task/BuiltIn/Composer/InstallTask.php
+++ b/src/Task/BuiltIn/Composer/InstallTask.php
@@ -36,7 +36,7 @@ class InstallTask extends AbstractTask
         $cmd = sprintf('%s install %s', $options['path'], $options['flags']);
 
         /** @var Process $process */
-        $process = $this->runtime->runCommand(trim($cmd));
+        $process = $this->runtime->runCommand(trim($cmd), 600);
 
         return $process->isSuccessful();
     }


### PR DESCRIPTION
The default composer:install will only run for 120 seconds which is not enough on all hosts…