### PR TITLE
Add build in npm install task

### DIFF
--- a/src/Task/BuiltIn/Npm/InstallTask.php
+++ b/src/Task/BuiltIn/Npm/InstallTask.php
@@ -1,0 +1,44 @@
+<?php
+/*
+ * This file is part of the Magallanes package.
+ *
+ * (c) Andrés Montañez <andres@andresmontanez.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mage\Task\BuiltIn\Npm;
+
+use Symfony\Component\Process\Process;
+use Mage\Task\AbstractTask;
+
+/**
+ * NPM Task - Installs npn packages
+ *
+ * @author Benjamin Gutmann <benjamin.gutmann@bestit-online.de>
+ * @author Alexander Schneider <alexanderschneider85@gmail.com>
+ */
+class InstallTask extends AbstractTask
+{
+    public function getName()
+    {
+        return 'npm/install';
+    }
+
+    public function getDescription()
+    {
+        return '[NPM] Install';
+    }
+
+    public function execute()
+    {
+        $flags = isset($this->options['flags']) ? $this->options['flags'] : '';
+        $cmd = sprintf('npm install %s', $flags);
+
+        /** @var Process $process */
+        $process = $this->runtime->runCommand($cmd);
+
+        return $process->isSuccessful();
+    }
+}

--- a/tests/Task/BuiltIn/Npm/InstallTaskTest.php
+++ b/tests/Task/BuiltIn/Npm/InstallTaskTest.php
@@ -1,0 +1,44 @@
+<?php
+/*
+ * This file is part of the Magallanes package.
+ *
+ * (c) Andrés Montañez <andres@andresmontanez.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Mage\Tests\Task\BuiltIn\Npm;
+
+use Mage\Task\BuiltIn\Npm\InstallTask;
+use Mage\Tests\Runtime\RuntimeMockup;
+use PHPUnit_Framework_TestCase as TestCase;
+
+class InstallTaskTest extends TestCase
+{
+    public function testInstallTask()
+    {
+        $runtime = new RuntimeMockup();
+        $runtime->setConfiguration(['environments' => ['test' => []]]);
+        $runtime->setEnvironment('test');
+
+        $task = new InstallTask();
+        $task->setOptions(['flags' => '--flags']);
+        $task->setRuntime($runtime);
+        $this->assertEquals('[NPM] Install', $task->getDescription());
+
+        $task->execute();
+
+        $ranCommands = $runtime->getRanCommands();
+        $testCase = array(
+            0 => 'npm install --flags',
+        );
+
+        // Check total of Executed Commands
+        $this->assertEquals(count($testCase), count($ranCommands));
+
+        // Check Generated Commands
+        foreach ($testCase as $index => $command) {
+            $this->assertEquals($command, $ranCommands[$index]);
+        }
+    }
+}


### PR DESCRIPTION
Npm is a standard tool for web application development and required for grunt and bower so it should be integrated. This PR adds a build in task for npm.