### PR TITLE
Feature/tar directory option

### DIFF
--- a/tests/Command/BuiltIn/DeployCommandWithReleasesTest.php
+++ b/tests/Command/BuiltIn/DeployCommandWithReleasesTest.php
@@ -118,6 +118,56 @@ class DeployCommandWithReleasesTest extends TestCase
         $this->assertEquals(0, $tester->getStatusCode());
     }
 
+    public function testDeploymentWithReleasesWithTarDirCommands()
+    {
+        $application = new MageApplicationMockup(__DIR__ . '/../../Resources/testhost-with-tar-dir.yml');
+
+        $application->getRuntime()->setReleaseId('20170101015120');
+
+        /** @var AbstractCommand $command */
+        $command = $application->find('deploy');
+        $this->assertTrue($command instanceof DeployCommand);
+
+        $tester = new CommandTester($command);
+        $tester->execute(['command' => $command->getName(), 'environment' => 'test']);
+
+        $ranCommands = $application->getRuntime()->getRanCommands();
+
+        $testCase = array(
+            0 => 'git branch | grep "*"',
+            1 => 'git checkout test',
+            2 => 'git pull',
+            3 => 'composer install --optimize-autoloader',
+            4 => 'composer dump-autoload --optimize',
+            5 => 'tar cfzp /tmp/mageXYZ -C ./dir --exclude=".git" --exclude="./var/cache/*" --exclude="./var/log/*" --exclude="./web/app_dev.php" ./',
+            6 => 'ssh -p 22 -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no tester@testhost "mkdir -p /var/www/test/releases/1234567890"',
+            7 => 'scp -P 22 -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no /tmp/mageXYZ tester@testhost:/var/www/test/releases/1234567890/mageXYZ',
+            8 => 'ssh -p 22 -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no tester@testhost "cd /var/www/test/releases/1234567890 && tar xfzop mageXYZ"',
+            9 => 'ssh -p 22 -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no tester@testhost "rm /var/www/test/releases/1234567890/mageXYZ"',
+            10 => 'ssh -p 22 -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no tester@testhost "cd /var/www/test/releases/1234567890 && bin/console cache:warmup --env=dev"',
+            11 => 'ssh -p 22 -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no tester@testhost "cd /var/www/test/releases/1234567890 && bin/console assets:install web --env=dev --symlink --relative"',
+            12 => 'ssh -p 22 -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no tester@testhost "cd /var/www/test/releases/1234567890 && bin/console assetic:dump --env=dev"',
+            13 => 'ssh -p 22 -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no tester@testhost "cd /var/www/test && ln -snf releases/1234567890 current"',
+            14 => 'ssh -p 22 -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no tester@testhost "ls -1 /var/www/test/releases"',
+            15 => 'ssh -p 22 -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no tester@testhost "rm -rf /var/www/test/releases/20170101015110"',
+            16 => 'ssh -p 22 -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no tester@testhost "rm -rf /var/www/test/releases/20170101015111"',
+            17 => 'ssh -p 22 -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no tester@testhost "rm -rf /var/www/test/releases/20170101015112"',
+            18 => 'ssh -p 22 -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no tester@testhost "rm -rf /var/www/test/releases/20170101015113"',
+            19 => 'rm /tmp/mageXYZ',
+            20 => 'git checkout master',
+        );
+
+        // Check total of Executed Commands
+        $this->assertEquals(count($testCase), count($ranCommands));
+
+        // Check Generated Commands
+        foreach ($testCase as $index => $command) {
+            $this->assertEquals($command, $ranCommands[$index]);
+        }
+
+        $this->assertEquals(0, $tester->getStatusCode());
+    }
+
     public function testDeploymentWithoutReleasesTarPrepare()
     {
         $application = new MageApplicationMockup(__DIR__ . '/../../Resources/testhost-force-tar1.yml');

--- a/tests/Resources/testhost-with-tar-dir.yml
+++ b/tests/Resources/testhost-with-tar-dir.yml
@@ -1,0 +1,28 @@
+magephp:
+    log_dir: /tmp
+    environments:
+        test:
+            user: tester
+            branch: test
+            tar_dir: ./dir
+            host_path: /var/www/test
+            releases: 4
+            exclude:
+                - ./dir/var/cache/*
+                - ./dir/var/log/*
+                - ./dir/web/app_dev.php
+                -
+                -
+            hosts:
+                - testhost
+            pre-deploy:
+                - git/update
+                - composer/install
+                - composer/dump-autoload
+            on-deploy:
+                - symfony/cache-warmup: { env: 'dev' }
+                - symfony/assets-install: { env: 'dev' }
+                - symfony/assetic-dump: { env: 'dev' }
+            on-release:
+            post-release:
+            post-deploy:


### PR DESCRIPTION
Currently there is now easy way to use the -C flag for creating the tar archive. This PR creates a new option to the .mage.yml `tar_dir` to set the -C flag option.