### PR TITLE
Feature/ssh base64 key task

### DIFF
--- a/src/Task/BuiltIn/Ssh/CreateKeyFromBase64Task.php
+++ b/src/Task/BuiltIn/Ssh/CreateKeyFromBase64Task.php
@@ -1,0 +1,63 @@
+<?php
+/*
+ * This file is part of the Magallanes package.
+ *
+ * (c) Andrés Montañez <andres@andresmontanez.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mage\Task\BuiltIn\Ssh;
+
+use Mage\Task\Exception\ErrorException;
+use Symfony\Component\Process\Process;
+use Mage\Task\AbstractTask;
+
+/**
+ * Ssh Task - Create key from base 64 encoded string
+ *
+ * @author Benjamin Gutmann <benjamin.gutmann@bestit-online.de>
+ * @author Alexander Schneider <alexanderschneider85@gmail.com>
+ */
+class CreateKeyFromBase64Task extends AbstractTask
+{
+    public function getName()
+    {
+        return 'ssh/create-key-from-base64';
+    }
+
+    public function getDescription()
+    {
+        return '[SSH] Create ssh key from base64';
+    }
+
+    public function execute()
+    {
+        if (!array_key_exists('base64Key', $this->options)
+            && !array_key_exists('base64KeyFromEnvVar', $this->options)
+        ) {
+            throw new ErrorException('Parameter "base64Key" or "base64KeyFromEnvVar" is required.');
+        } elseif (array_key_exists('base64Key', $this->options)
+            && array_key_exists('base64KeyFromEnvVar', $this->options)
+        ) {
+            throw new ErrorException('Either "base64Key" or "base64KeyFromEnvVar" can be set.');
+        }
+
+        $home = getenv('HOME');
+        $sshDir = $home.DIRECTORY_SEPARATOR.'.ssh';
+        
+        if (!is_dir($sshDir)) {
+            mkdir($sshDir);
+        }
+        
+        $base64Key = isset($this->options['base64KeyFromEnvVar']) ?
+            getenv($this->options['base64KeyFromEnvVar']) : $this->options['base64Key'];
+
+        $keyFileName = isset($this->options['keyFileName']) ? $this->options['keyFileName'] : 'id_rsa';
+        $sshKey = base64_decode($base64Key);
+        $sshFile = $sshDir.DIRECTORY_SEPARATOR.$keyFileName;
+        $success = (file_put_contents($sshFile, $sshKey) !== false);
+        return ($success) ? chmod($sshFile, 0600) : false;
+    }
+}

--- a/src/Task/BuiltIn/Ssh/CreateKeyFromBase64Task.php
+++ b/src/Task/BuiltIn/Ssh/CreateKeyFromBase64Task.php
@@ -11,7 +11,6 @@
 namespace Mage\Task\BuiltIn\Ssh;
 
 use Mage\Task\Exception\ErrorException;
-use Symfony\Component\Process\Process;
 use Mage\Task\AbstractTask;
 
 /**

--- a/tests/Task/BuiltIn/Ssh/CreateKeyFromBase64TaskTest.php
+++ b/tests/Task/BuiltIn/Ssh/CreateKeyFromBase64TaskTest.php
@@ -1,0 +1,50 @@
+<?php
+/*
+ * This file is part of the Magallanes package.
+ *
+ * (c) Andrés Montañez <andres@andresmontanez.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mage\Tests\Task\BuiltIn\Ssh;
+
+use Mage\Task\BuiltIn\Ssh\CreateKeyFromBase64Task;
+use PHPUnit_Framework_TestCase as TestCase;
+
+class CreateKeyFromBase64TaskTest extends TestCase
+{
+    public function testCreateKeyFromBase64Task()
+    {
+        $tmpDir = '/tmp/mage_ssh_test';
+
+        if (file_exists($tmpDir)) {
+            unlink($tmpDir);
+        }
+
+        mkdir($tmpDir, 0777, true);
+        putenv('HOME='.$tmpDir);
+
+        /**
+         * @var \PHPUnit_Framework_MockObject_MockObject|\Mage\Runtime\Runtime $runtime
+         */
+        $runtime = $this->getMock('\Mage\Runtime\Runtime');
+        $task = new CreateKeyFromBase64Task();
+
+        $task->setOptions(['base64Key' => base64_encode('base64KeyValue')]);
+        $task->setRuntime($runtime);
+        $this->assertEquals('[SSH] Create ssh key from base64', $task->getDescription());
+
+        self::assertTrue($task->execute());
+        self::assertTrue(file_exists($tmpDir.'/.ssh/id_rsa'));
+        self::assertEquals('base64KeyValue', file_get_contents($tmpDir.'/.ssh/id_rsa'));
+
+        putenv('BASE64_KEY_ENV='.base64_encode('base64KeyFromEnvVarValue'));
+        $task->setOptions(['base64KeyFromEnvVar' => 'BASE64_KEY_ENV', 'keyFileName' => 'custom_key']);
+
+        self::assertTrue($task->execute());
+        self::assertTrue(file_exists($tmpDir.'/.ssh/custom_key'));
+        self::assertEquals('base64KeyFromEnvVarValue', file_get_contents($tmpDir.'/.ssh/custom_key'));
+    }
+}


### PR DESCRIPTION
Sometimes you don't want to add your deployment ssh key to your server or if you using such systems like bitbucket pipelines you don't want to add it to your docker container. This provides a method to create from a base64 encoded ssh key a ssh key for the current user. The base64 key can be added directly to your yaml using `base64Key` see the following example:

```yaml
pre-deploy:
  - ssh/create-key-from-base64: { base64Key: 'BASE64ENCODEDSTRING' }
```

or will be taken from an environment variable using `base64KeyFromEnvVar`. Furthermore you can choose a file name for the key with `keyFileName` See the following example.

```yaml
pre-deploy:
  - ssh/create-key-from-base64: { base64KeyFromEnvVar: 'SSH_KEY_ENV_VAR', keyFileName: 'custom_key' }
```