### PR TITLE
[FEATURE] Add timeout option for assetic:dump task

### DIFF
--- a/src/Task/BuiltIn/Symfony/AsseticDumpTask.php
+++ b/src/Task/BuiltIn/Symfony/AsseticDumpTask.php
@@ -36,7 +36,7 @@ class AsseticDumpTask extends AbstractTask
         $command = sprintf('%s assetic:dump --env=%s %s', $options['console'], $options['env'], $options['flags']);
 
         /** @var Process $process */
-        $process = $this->runtime->runCommand(trim($command));
+        $process = $this->runtime->runCommand(trim($command), $options['timeout']);
 
         return $process->isSuccessful();
     }
@@ -44,7 +44,7 @@ class AsseticDumpTask extends AbstractTask
     protected function getOptions()
     {
         $options = array_merge(
-            ['console' => 'bin/console', 'env' => 'dev', 'flags' => ''],
+            ['console' => 'bin/console', 'env' => 'dev', 'flags' => '', 'timeout' => 120],
             $this->runtime->getMergedOption('symfony'),
             $this->options
         );

--- a/tests/Runtime/RuntimeMockup.php
+++ b/tests/Runtime/RuntimeMockup.php
@@ -16,11 +16,17 @@ use Symfony\Component\Process\Process;
 class RuntimeMockup extends Runtime
 {
     protected $ranCommands = [];
+    protected $ranCommandTimeouts = [];
     protected $forceFail = [];
 
     public function getRanCommands()
     {
         return $this->ranCommands;
+    }
+
+    public function getRanCommandTimeoutFor($cmd)
+    {
+        return $this->ranCommandTimeouts[$cmd] ?? null;
     }
 
     /**
@@ -44,6 +50,7 @@ class RuntimeMockup extends Runtime
     public function runLocalCommand($cmd, $timeout = 120)
     {
         $this->ranCommands[] = $cmd;
+        $this->ranCommandTimeouts[$cmd] = $timeout;
 
         $process = new ProcessMockup($cmd);
         $process->forceFail = $this->forceFail;

--- a/tests/Runtime/RuntimeMockup.php
+++ b/tests/Runtime/RuntimeMockup.php
@@ -26,7 +26,7 @@ class RuntimeMockup extends Runtime
 
     public function getRanCommandTimeoutFor($cmd)
     {
-        return $this->ranCommandTimeouts[$cmd] ?? null;
+        return isset($this->ranCommandTimeouts[$cmd]) ? $this->ranCommandTimeouts[$cmd] : null;
     }
 
     /**

--- a/tests/Task/BuiltIn/Symfony/AsseticDumpTaskTest.php
+++ b/tests/Task/BuiltIn/Symfony/AsseticDumpTaskTest.php
@@ -1,0 +1,70 @@
+<?php declare(strict_types=1);
+
+namespace Mage\tests\Task\BuiltIn\Symfony;
+
+
+use Mage\Task\BuiltIn\Symfony\AsseticDumpTask;
+use Mage\Tests\Runtime\RuntimeMockup;
+
+class AsseticDumpTaskTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var RuntimeMockup
+     */
+    private $runtime;
+
+    public function setUp()
+    {
+        $this->runtime = new RuntimeMockup();
+        $this->runtime->setConfiguration(['environments' => ['test' => []]]);
+        $this->runtime->setEnvironment('test');
+    }
+
+    public function testAsseticDumpTask()
+    {
+        $task = new AsseticDumpTask();
+        $task->setOptions(['env' => 'test']);
+        $task->setRuntime($this->runtime);
+        $this->assertEquals('[Symfony] Assetic Dump', $task->getDescription());
+        $task->execute();
+
+        $testCase = [
+            'bin/console assetic:dump --env=test' => 120,
+        ];
+
+        $this->assertRanCommands($testCase);
+    }
+
+    public function testAsseticDumpTaskWithTimeoutOption()
+    {
+        $task = new AsseticDumpTask();
+        $task->setOptions(['env' => 'test', 'timeout' => 300]);
+        $task->setRuntime($this->runtime);
+        $task->execute();
+
+
+        $testCase = [
+            'bin/console assetic:dump --env=test' => 300,
+        ];
+
+        $this->assertRanCommands($testCase);
+    }
+
+    /**
+     * @param $testCase
+     */
+    private function assertRanCommands($testCase)
+    {
+        $ranCommands = $this->runtime->getRanCommands();
+
+        // Check total of Executed Commands
+        $this->assertEquals(count($testCase), count($ranCommands));
+
+        // Check Generated Commands
+        $index = 0;
+        foreach ($testCase as $command => $timeout) {
+            $this->assertEquals($command, $ranCommands[$index++]);
+            $this->assertEquals($timeout, $this->runtime->getRanCommandTimeoutFor($command));
+        }
+    }
+}

--- a/tests/Task/BuiltIn/Symfony/AsseticDumpTaskTest.php
+++ b/tests/Task/BuiltIn/Symfony/AsseticDumpTaskTest.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php
 
 namespace Mage\tests\Task\BuiltIn\Symfony;
 


### PR DESCRIPTION
Adds a timeout option for the assetic:dump task.

This gives the possibility to overwrite the default timeout (120 seconds) for a long running assetic:dump processes.