### PR TITLE
Allow overriding a binary

### DIFF
--- a/src/Runtime/Runtime.php
+++ b/src/Runtime/Runtime.php
@@ -156,6 +156,26 @@ class Runtime
     }
 
     /**
+     * Retrieve a binary and check if it was changed in the "binary-map" configuration.
+     * This allows e.g. to override "tar" by "gnutar" etc.
+     *
+     * @param string $binary
+     *
+     * @return string
+     */
+    public function getBinary($binary)
+    {
+        $map = $this->getConfigOption('binary-map', []);
+
+        if (!array_key_exists($binary, $map)) {
+
+            return $binary;
+        }
+
+        return $map[$binary];
+    }
+
+    /**
      * Sets the Logger instance
      *
      * @param LoggerInterface $logger Logger instance

--- a/src/Task/BuiltIn/Deploy/RsyncTask.php
+++ b/src/Task/BuiltIn/Deploy/RsyncTask.php
@@ -46,7 +46,18 @@ class RsyncTask extends AbstractTask
 
         $excludes = $this->getExcludes();
         $from = $this->runtime->getEnvOption('from', './');
-        $cmdRsync = sprintf('rsync -e "ssh -p %d %s" %s %s %s %s@%s:%s', $sshConfig['port'], $sshConfig['flags'], $flags, $excludes, $from, $user, $host, $targetDir);
+        $cmdRsync = sprintf('%s -e "%s -p %d %s" %s %s %s %s@%s:%s',
+            $this->runtime->getBinary('rsync'),
+            $this->runtime->getBinary('ssh'),
+            $sshConfig['port'],
+            $sshConfig['flags'],
+            $flags,
+            $excludes,
+            $from,
+            $user,
+            $host,
+            $targetDir
+        );
 
         /** @var Process $process */
         $process = $this->runtime->runLocalCommand($cmdRsync, 600);

--- a/src/Task/BuiltIn/Deploy/Tar/CopyTask.php
+++ b/src/Task/BuiltIn/Deploy/Tar/CopyTask.php
@@ -49,12 +49,21 @@ class CopyTask extends AbstractTask
         $tarLocal = $this->runtime->getVar('tar_local');
         $tarRemote = basename($tarLocal);
 
-        $cmdCopy = sprintf('scp -P %d %s %s %s@%s:%s/%s', $sshConfig['port'], $sshConfig['flags'], $tarLocal, $user, $host, $targetDir, $tarRemote);
+        $cmdCopy = sprintf('%s -P %d %s %s %s@%s:%s/%s',
+            $this->runtime->getBinary('scp'),
+            $sshConfig['port'],
+            $sshConfig['flags'],
+            $tarLocal,
+            $user,
+            $host,
+            $targetDir,
+            $tarRemote
+        );
 
         /** @var Process $process */
         $process = $this->runtime->runLocalCommand($cmdCopy, 300);
         if ($process->isSuccessful()) {
-            $cmdUnTar = sprintf('cd %s && tar %s %s', $targetDir, $flags, $tarRemote);
+            $cmdUnTar = sprintf('cd %s && %s %s %s', $targetDir, $this->runtime->getBinary('tar'), $flags, $tarRemote);
             $process = $this->runtime->runRemoteCommand($cmdUnTar, false, 600);
             if ($process->isSuccessful()) {
                 $cmdDelete = sprintf('rm %s/%s', $targetDir, $tarRemote);

--- a/src/Task/BuiltIn/Deploy/Tar/PrepareTask.php
+++ b/src/Task/BuiltIn/Deploy/Tar/PrepareTask.php
@@ -43,7 +43,7 @@ class PrepareTask extends AbstractTask
         $excludes = $this->getExcludes();
         $flags = $this->runtime->getEnvOption('tar_create', 'cfzp');
         $from = $this->runtime->getEnvOption('from', './');
-        $cmdTar = sprintf('tar %s %s %s %s', $flags, $tarLocal, $excludes, $from);
+        $cmdTar = sprintf('%s %s %s %s %s', $this->runtime->getBinary('tar'), $flags, $tarLocal, $excludes, $from);
 
         /** @var Process $process */
         $process = $this->runtime->runLocalCommand($cmdTar, 300);

--- a/tests/Resources/binary-map.yml
+++ b/tests/Resources/binary-map.yml
@@ -1,0 +1,18 @@
+magephp:
+    binary-map:
+        tar: gnutar
+    environments:
+        test:
+            user: tester
+            from: ./dist
+            host_path: /var/www/test
+            releases: 4
+            exclude:
+                - ./var/cache/*
+                - ./var/log/*
+                - ./web/app_dev.php
+                -
+                -
+            hosts:
+                - testhost
+


### PR DESCRIPTION
Hey Andres,

I currently encounter a typical BSD tar/GNU tar issue. The `exclude` option does not work exactly the same which is why you have to specify the exclude in a way that they match your current tar settings. I came up with the idea to have a simple `binary-map`.
So now I can install e.g. `gnu-tar` (or `gtar` etc.) next to my `tar` and specify a mapper:

```yaml
magephp:
    binary-map:
        tar: gnutar
```

That allows me to have different `exclude` definitions on different machines I'm working on. Happy to hear your feedback on this.