### PR TITLE
[FEATURE]Support colon notation in host config definition

### DIFF
--- a/src/Runtime/Runtime.php
+++ b/src/Runtime/Runtime.php
@@ -457,10 +457,10 @@ class Runtime
      */
     public function getSSHConfig()
     {
-        $sshConfig = $this->getEnvOption('ssh', ['port' => '22', 'flags' => '-q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no']);
+        $sshConfig = $this->getEnvOption('ssh', ['flags' => '-q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no']);
 
         if (!array_key_exists('port', $sshConfig)) {
-            $sshConfig['port'] = '22';
+            $sshConfig['port'] = $this->getHostPort();
         }
 
         if (!array_key_exists('flags', $sshConfig)) {
@@ -468,6 +468,17 @@ class Runtime
         }
 
         return $sshConfig;
+    }
+
+    /**
+     * Get the current Host Port or default ssh port
+     *
+     * @return integer
+     */
+    public function getHostPort()
+    {
+        $info = explode(':', $this->getWorkingHost());
+        return isset($info[1]) ? $info[1] : '22';
     }
 
     /**

--- a/tests/Runtime/RuntimeTest.php
+++ b/tests/Runtime/RuntimeTest.php
@@ -119,6 +119,20 @@ class RuntimeTest extends TestCase
         $this->assertEquals('-q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no', $sshConfig['flags']);
     }
 
+    public function testSSHConfigPortDefinedInHostNotation()
+    {
+        $runtime = new Runtime();
+        $runtime->setWorkingHost('223.12.24.64:1056');
+        $sshConfig = $runtime->getSSHConfig();
+
+        $this->assertEquals('1056', $sshConfig['port']);
+
+        $runtime->setWorkingHost('223.12.24.64');
+        $sshConfig = $runtime->getSSHConfig();
+
+        $this->assertEquals('22', $sshConfig['port']);
+    }
+
     public function testSSHConfigEmptyOptions()
     {
         $runtime = new Runtime();


### PR DESCRIPTION
Support configure different ports on same host in `host:port` notation.