### PR TITLE
Added an ssh command to allow for faster ssh connections

### DIFF
--- a/src/Command/BuiltIn/SshCommand.php
+++ b/src/Command/BuiltIn/SshCommand.php
@@ -1,0 +1,95 @@
+<?php
+/*
+ * This file is part of the Magallanes package.
+ *
+ * (c) Andrés Montañez <andres@andresmontanez.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mage\Command\BuiltIn;
+
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Mage\Command\AbstractCommand;
+use Symfony\Component\Process\Exception\RuntimeException;
+use Symfony\Component\Process\Process;
+
+/**
+ * SSH Command, allows to connect via SSH to a host with environment
+ * specific configuration.
+ *
+ * @author Yanick Witschi <https://github.com/Toflar>
+ */
+class SshCommand extends AbstractCommand
+{
+    /**
+     * Configure the Command
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('ssh')
+            ->setDescription('Connects to an environment via SSH so you do not have to remember/copy&paste the user, host, port, key etc.')
+            ->addArgument('environment', InputArgument::REQUIRED, 'Name of the environment to connect to')
+            ->addOption('host', null, InputOption::VALUE_OPTIONAL, 'Host of environment to connect to (by default the first one in the hosts array).', 0)
+        ;
+    }
+
+    /**
+     * Executes the Command
+     *
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return int
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->requireConfig();
+        $env = $input->getArgument('environment');
+        $this->runtime->setEnvironment($env);
+        $user = $this->runtime->getEnvOption('user', $this->runtime->getCurrentUser());
+        $sshConfig = $this->runtime->getSSHConfig();
+        $hosts = $this->runtime->getEnvOption('hosts');
+        $host = $input->getOption('host');
+
+        // Allow to pass the host as string
+        if (!is_numeric($host)) {
+            if (!in_array($host, $hosts, true)) {
+                $output->writeln(sprintf('<error>%s</error>', sprintf('The host "%s" does not exist in environment "%s".', $host, $env)));
+
+                return 1;
+            }
+        } else {
+            // Otherwise take the index (e.g. if you want to select the 3rd host, execute "--host=2"
+            $host = (int) $host;
+            if (!isset($hosts[$host])) {
+                $output->writeln(sprintf('<error>%s</error>', sprintf('The host key "%s" does not exist in environment "%s".', $host, $env)));
+
+                return 1;
+            }
+
+            $host = $hosts[$host];
+        }
+
+        $cmd = sprintf('ssh -p %d %s %s@%s', $sshConfig['port'], $sshConfig['flags'], $user, $host);
+        $process = new Process($cmd);
+
+        try {
+            $process->setTty(true);
+        } catch (RuntimeException $e) {
+            $output->writeln(sprintf('<error>%s</error>', $e->getMessage()));
+
+            return 126;
+        }
+
+        $output->writeln(sprintf('Creating secure connection using the following command: %s', $process->getCommandLine()));
+        $process->mustRun();
+        $output->writeln('Disconnecting...');
+
+        return 0;
+    }
+}


### PR DESCRIPTION
Hey Andres,

I often find myself wanting to ssh to a certain environment because I quickly need to check something. When you have a lot of environments targeting different servers and using different ports and public keys that can be quite annoying because you need to copy&paste the information.
I thought there must be a better way because all of it is configured in `mage.yml` so why not reuse it? 😄 
I've invented a `mage ssh` command you can use as follows:

* `mage ssh production`, connects to the `production` environment using the configuration of that environment and the first host in the `hosts` definition.

If you want to connect to a different host, you can either specify it using a string or the array index. So given the config

```yaml
hosts:
    - webserver1
    - webserver2
    - webserver3
```

and you want to ssh to `webserver3`, you can work with both of these:

* `mage ssh --host=webserver3 production`
* `mage ssh --host=2 production`

No unit tests there because I really don't know what I should test here. TTY testing is very hard and probably not worth the pain because that command is just a helper and not a deployment relevant piece of code at all.