### PR TITLE
Make tar commands timeout configurable

### DIFF
--- a/src/Task/BuiltIn/Deploy/Tar/CopyTask.php
+++ b/src/Task/BuiltIn/Deploy/Tar/CopyTask.php
@@ -45,7 +45,7 @@ class CopyTask extends AbstractTask
 
         $tarPath = $this->runtime->getEnvOption('tar_extract_path', 'tar');
         $flags = $this->runtime->getEnvOption('tar_extract', 'xfzop');
-        $timeout = $this->runtime->getEnvOption('tar_timeout', 600);
+        $timeout = $this->runtime->getEnvOption('tar_timeout', 300);
         $targetDir = sprintf('%s/releases/%s', $hostPath, $currentReleaseId);
 
         $tarLocal = $this->runtime->getVar('tar_local');
@@ -54,10 +54,10 @@ class CopyTask extends AbstractTask
         $cmdCopy = sprintf('scp -P %d %s %s %s@%s:%s/%s', $sshConfig['port'], $sshConfig['flags'], $tarLocal, $user, $host, $targetDir, $tarRemote);
 
         /** @var Process $process */
-        $process = $this->runtime->runLocalCommand($cmdCopy, 300);
+        $process = $this->runtime->runLocalCommand($cmdCopy, $timeout);
         if ($process->isSuccessful()) {
             $cmdUnTar = sprintf('cd %s && %s %s %s', $targetDir, $tarPath, $flags, $tarRemote);
-            $process = $this->runtime->runRemoteCommand($cmdUnTar, false, $timeout);
+            $process = $this->runtime->runRemoteCommand($cmdUnTar, false, $timeout + 300);
             if ($process->isSuccessful()) {
                 $cmdDelete = sprintf('rm %s/%s', $targetDir, $tarRemote);
                 $process = $this->runtime->runRemoteCommand($cmdDelete, false);

--- a/src/Task/BuiltIn/Deploy/Tar/CopyTask.php
+++ b/src/Task/BuiltIn/Deploy/Tar/CopyTask.php
@@ -57,7 +57,7 @@ class CopyTask extends AbstractTask
         $process = $this->runtime->runLocalCommand($cmdCopy, $timeout);
         if ($process->isSuccessful()) {
             $cmdUnTar = sprintf('cd %s && %s %s %s', $targetDir, $tarPath, $flags, $tarRemote);
-            $process = $this->runtime->runRemoteCommand($cmdUnTar, false, $timeout + 300);
+            $process = $this->runtime->runRemoteCommand($cmdUnTar, false, $timeout * 2);
             if ($process->isSuccessful()) {
                 $cmdDelete = sprintf('rm %s/%s', $targetDir, $tarRemote);
                 $process = $this->runtime->runRemoteCommand($cmdDelete, false);

--- a/src/Task/BuiltIn/Deploy/Tar/CopyTask.php
+++ b/src/Task/BuiltIn/Deploy/Tar/CopyTask.php
@@ -45,6 +45,7 @@ class CopyTask extends AbstractTask
 
         $tarPath = $this->runtime->getEnvOption('tar_extract_path', 'tar');
         $flags = $this->runtime->getEnvOption('tar_extract', 'xfzop');
+        $timeout = $this->runtime->getEnvOption('tar_timeout', 600);
         $targetDir = sprintf('%s/releases/%s', $hostPath, $currentReleaseId);
 
         $tarLocal = $this->runtime->getVar('tar_local');
@@ -56,7 +57,7 @@ class CopyTask extends AbstractTask
         $process = $this->runtime->runLocalCommand($cmdCopy, 300);
         if ($process->isSuccessful()) {
             $cmdUnTar = sprintf('cd %s && %s %s %s', $targetDir, $tarPath, $flags, $tarRemote);
-            $process = $this->runtime->runRemoteCommand($cmdUnTar, false, 600);
+            $process = $this->runtime->runRemoteCommand($cmdUnTar, false, $timeout);
             if ($process->isSuccessful()) {
                 $cmdDelete = sprintf('rm %s/%s', $targetDir, $tarRemote);
                 $process = $this->runtime->runRemoteCommand($cmdDelete, false);

--- a/src/Task/BuiltIn/Deploy/Tar/PrepareTask.php
+++ b/src/Task/BuiltIn/Deploy/Tar/PrepareTask.php
@@ -43,11 +43,12 @@ class PrepareTask extends AbstractTask
         $excludes = $this->getExcludes();
         $tarPath = $this->runtime->getEnvOption('tar_create_path', 'tar');
         $flags = $this->runtime->getEnvOption('tar_create', 'cfzp');
+        $timeout = $this->runtime->getEnvOption('tar_timeout', 300);
         $from = $this->runtime->getEnvOption('from', './');
         $cmdTar = sprintf('%s %s %s %s %s', $tarPath, $flags, $tarLocal, $excludes, $from);
 
         /** @var Process $process */
-        $process = $this->runtime->runLocalCommand($cmdTar, 300);
+        $process = $this->runtime->runLocalCommand($cmdTar, $timeout);
         return $process->isSuccessful();
     }
 


### PR DESCRIPTION
**Use case:** Deploying a big Drupal project using releases.

**Problem:** tar commands fail because of the low value of the specified timeout in code.

**Solution:** if you set a timeout on built-in commands run by magallanes, you should also add the possibility to override this timeout, as some projects may need more time to tar / copy / untar the source code.

I added a _tar_timeout_ parameter for the commands run by the built in tar task, that can be specified alongside the other tar parameters:

```
environments:
        production:
            tar_timeout: <your value in seconds>
```

Note: the tar task is not only doing the tar / untar, but also the scp copy of the archive to the environment server, the _tar_timeout_ parameter will also impact the timeout of the scp command, by doubling the value of the parameter. For example if the parameter is set to 400 seconds, the timeout for the tar / untar commands will be 400 and the timeout for the scp command will be 800 seconds.