### PR TITLE
Added sleep task to allow delaying execution of other tasks

### DIFF
--- a/src/Task/BuiltIn/SleepTask.php
+++ b/src/Task/BuiltIn/SleepTask.php
@@ -1,0 +1,68 @@
+<?php
+/*
+ * This file is part of the Magallanes package.
+ *
+ * (c) Andrés Montañez <andres@andresmontanez.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mage\Task\BuiltIn;
+
+use Mage\Task\Exception\ErrorException;
+use Mage\Task\AbstractTask;
+
+/**
+ * Sleep task. Sleeps for a given number of seconds so you can delay task
+ * execution.
+ *
+ * @author Yanick Witschi <https://github.com/Toflar>
+ */
+class SleepTask extends AbstractTask
+{
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return 'sleep';
+    }
+
+    /**
+     * @return string
+     */
+    public function getDescription()
+    {
+        $options = $this->getOptions();
+
+        return sprintf('[Sleep] Sleeping for %s second(s)', (int) $options['seconds']);
+    }
+
+    /**
+     * @return bool
+     *
+     * @throws ErrorException
+     */
+    public function execute()
+    {
+        $options = $this->getOptions();
+
+        sleep((int) $options['seconds']);
+
+        return true;
+    }
+
+    /**
+     * @return array
+     */
+    protected function getOptions()
+    {
+        $options = array_merge(
+            ['seconds' => 1],
+            $this->options
+        );
+
+        return $options;
+    }
+}

--- a/tests/Task/BuiltIn/SleepTaskTest.php
+++ b/tests/Task/BuiltIn/SleepTaskTest.php
@@ -1,0 +1,31 @@
+<?php
+/*
+ * This file is part of the Magallanes package.
+ *
+ * (c) Andrés Montañez <andres@andresmontanez.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mage\Tests\Task\BuiltIn;
+
+use Mage\Task\BuiltIn\SleepTask;
+use Mage\Tests\Runtime\RuntimeMockup;
+use PHPUnit_Framework_TestCase as TestCase;
+
+class SleepTaskTest extends TestCase
+{
+    public function testCommand()
+    {
+        $runtime = new RuntimeMockup();
+        $runtime->setConfiguration(['environments' => ['test' => []]]);
+        $runtime->setEnvironment('test');
+
+        $task = new SleepTask();
+        $task->setRuntime($runtime);
+
+        $this->assertSame('[Sleep] Sleeping for 1 second(s)', $task->getDescription());
+        $task->execute();
+    }
+}


### PR DESCRIPTION
Sometimes that's helpful, like if you have to wait a few moments until e.g. the `current` symlink is ready and the server was able to update internally etc.