### PR TITLE
[FEATURE] allow "local deployments"

### DIFF
--- a/src/Runtime/Runtime.php
+++ b/src/Runtime/Runtime.php
@@ -444,8 +444,12 @@ class Runtime
             $cmdDelegate = sprintf('cd %s && %s', $hostPath, $cmdDelegate);
         }
 
-        $cmdRemote = str_replace('"', '\"', $cmdDelegate);
-        $cmdLocal = sprintf('ssh -p %d %s %s@%s "%s"', $sshConfig['port'], $sshConfig['flags'], $user, $host, $cmdRemote);
+        if ('localhost' !== $host) {
+            $cmdRemote = str_replace('"', '\"', $cmdDelegate);
+            $cmdLocal = sprintf('ssh -p %d %s %s@%s "%s"', $sshConfig['port'], $sshConfig['flags'], $user, $host, $cmdRemote);
+        } else {
+            $cmdLocal = $cmdDelegate;
+        }
 
         return $this->runLocalCommand($cmdLocal, $timeout);
     }


### PR DESCRIPTION
If the target host is "localhost", then skip building a SSH command and just execute a command locally. This should allow "local deployments" - e.g. to deploy to a staging or testing environment on localhost.