### PR TITLE
[bugfix] Update config for Travis CI in order to run tests in a containerized Trusty environment with PHP 7.2 and lowest dependencies on PHP 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,23 @@
 language: php
-php:
-  - '5.5'
-  - '5.6'
-  - '7.0'
-  - '7.1'
+
+dist: trusty
+
+sudo: false
+
+matrix:
+    fast_finish: true
+    include:
+        - php: 5.5
+        - php: 5.6
+        - php: 7.0
+        - php: 7.1
+        - php: 7.1
+          env: dependencies=lowest
+        - php: 7.2
 
 install:
-  - composer install
+  - composer install --optimize-autoloader --classmap-authoritative --no-interaction
+  - if [ "$dependencies" = "lowest" ]; then composer update --prefer-lowest --prefer-stable --optimize-autoloader --classmap-authoritative --no-interaction; fi;
 
 script:
   - mkdir -p build/logs

--- a/composer.json
+++ b/composer.json
@@ -13,16 +13,16 @@
   ],
   "require": {
     "php": ">=5.5.9",
-    "monolog/monolog": "^1.0",
+    "monolog/monolog": "^1.23",
     "symfony/console": "^3.0",
     "symfony/filesystem": "^3.0",
     "symfony/event-dispatcher": "^3.0",
     "symfony/finder": "^3.0",
-    "symfony/yaml": "^3.0",
+    "symfony/yaml": "^3.0.7",
     "symfony/process": "^3.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "4.8.*",
+    "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0",
     "satooshi/php-coveralls": "~1.0"
   },
   "autoload": {

--- a/src/Command/BuiltIn/DeployCommand.php
+++ b/src/Command/BuiltIn/DeployCommand.php
@@ -142,7 +142,7 @@ class DeployCommand extends AbstractCommand
 
     protected function runOnHosts(OutputInterface $output, $tasks)
     {
-        $hosts = $this->runtime->getEnvOption('hosts');
+        $hosts = $this->runtime->getEnvOption('hosts', []);
         if (count($hosts) == 0) {
             $output->writeln(sprintf('    No hosts defined, skipping %s tasks', $this->getStageName()));
             $output->writeln('');

--- a/src/Command/BuiltIn/Releases/ListCommand.php
+++ b/src/Command/BuiltIn/Releases/ListCommand.php
@@ -73,7 +73,7 @@ class ListCommand extends AbstractCommand
 
             $output->writeln('');
 
-            $hosts = $this->runtime->getEnvOption('hosts');
+            $hosts = $this->runtime->getEnvOption('hosts', []);
             if (count($hosts) == 0) {
                 $output->writeln('No hosts defined');
                 $output->writeln('');


### PR DESCRIPTION
|Q            |A     |
|---          |---   |
|Branch       |master|
|Bug fix?     |no    |
|New feature? |no    |
|BC breaks?   |no    |
|Deprecations?|no    |
|Tests pass?  |yes   |
|Fixed tickets|n/a   |
|License      |MIT   |
|Doc PR       |n/a   |

* PSR-3 compatibility was added in [`monolog/monolog:1.23.0`](https://github.com/Seldaek/monolog/commit/7913cd2c4d0f97c8903c1c00413621128aa409da);
* Bumped to `symfony/yaml:3.0.7` in order to avoid errors like `Mage\Runtime\Exception\RuntimeException: Error parsing the file "/home/travis/build/andres-montanez/Magallanes/tests/Command/BuiltIn/../../Resources/testhost.yml".`