### PR TITLE
Event subscribers

### DIFF
--- a/src/Event/RegisterCommandsEvent.php
+++ b/src/Event/RegisterCommandsEvent.php
@@ -20,7 +20,7 @@ class RegisterCommandsEvent extends Event
     /**
      * @var Command[]
      */
-    private $commands;
+    private $commands = [];
 
     /**
      * @return Command[]

--- a/src/Event/RegisterCommandsEvent.php
+++ b/src/Event/RegisterCommandsEvent.php
@@ -1,0 +1,56 @@
+<?php
+/*
+ * This file is part of the Magallanes package.
+ *
+ * (c) Andrés Montañez <andres@andresmontanez.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Mage\Event;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\EventDispatcher\Event;
+
+class RegisterCommandsEvent extends Event
+{
+    const EVENT_NAME = 'mage.event.register_commands';
+
+    /**
+     * @var Command[]
+     */
+    private $commands;
+
+    /**
+     * @return Command[]
+     */
+    public function getCommands()
+    {
+        return $this->commands;
+    }
+
+    /**
+     * @param array $commands
+     *
+     * @return RegisterCommandsEvent
+     */
+    public function setCommands(array $commands)
+    {
+        $this->commands = [];
+
+        foreach ($commands as $command) {
+            $this->addCommand($command);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param Command $command
+     */
+    public function addCommand(Command $command)
+    {
+        $this->commands[] = $command;
+    }
+}

--- a/src/MageApplication.php
+++ b/src/MageApplication.php
@@ -11,6 +11,7 @@
 namespace Mage;
 
 use Mage\Command\AbstractCommand;
+use Mage\Event\RegisterCommandsEvent;
 use Mage\Runtime\Runtime;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Finder\Finder;
@@ -58,6 +59,13 @@ class MageApplication extends Application
         $this->runtime = $this->instantiateRuntime();
         $this->runtime->setEventDispatcher($dispatcher);
         $this->loadBuiltInCommands();
+
+        $event = new RegisterCommandsEvent();
+        $dispatcher->dispatch(RegisterCommandsEvent::EVENT_NAME, $event);
+
+        foreach ($event->getCommands() as $command) {
+            $this->add($command);
+        }
     }
 
     /**

--- a/src/Runtime/Runtime.php
+++ b/src/Runtime/Runtime.php
@@ -15,6 +15,7 @@ use Mage\Deploy\Strategy\RsyncStrategy;
 use Mage\Deploy\Strategy\StrategyInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Process\Process;
 use Mage\Runtime\Exception\RuntimeException;
 
@@ -45,6 +46,11 @@ class Runtime
      * @var string Stage of Deployment
      */
     protected $stage;
+
+    /**
+     * @var EventDispatcherInterface
+     */
+    protected $eventDispatcher;
 
     /**
      * @var string|null The host being deployed to
@@ -316,6 +322,21 @@ class Runtime
         return $this->stage;
     }
 
+    /**
+     * @return EventDispatcherInterface
+     */
+    public function getEventDispatcher()
+    {
+        return $this->eventDispatcher;
+    }
+
+    /**
+     * @param EventDispatcherInterface $eventDispatcher
+     */
+    public function setEventDispatcher(EventDispatcherInterface $eventDispatcher)
+    {
+        $this->eventDispatcher = $eventDispatcher;
+    }
     /**
      * Retrieve the defined Tasks for the current Environment and Stage
      *


### PR DESCRIPTION
There were already other issues about [registering custom commands](https://github.com/andres-montanez/Magallanes/issues/366) and I also [submitted a PR](https://github.com/andres-montanez/Magallanes/pull/402) for an ssh command which was declined and I have no possibility to add it on my own at the moment.

So I thought I'll come up with a simple concept that allows us to provide events for whatever extension point you may think of. The one that supports registering custom commands is just the first one but it serves as a useful example right away.

So subscribers are registered like so:

```yaml
magephp:
    subscribers:
        - Vendor\MageExtension\SuperEventSubscriber
```

All that class has to do is to implement the Symfony `EventSubscriberInterface` and register to any event we will add in the future.
The `Runtime` now has a `getEventDispatcher()` allowing to dispatch events everywhere within the application. You can do it in built-in tasks yourself or one can do it in custom tasks for whatever reason. This concept provides a lot of flexibility.

Using this concept, we can easily register a new command. So if I wanted to add my SSH command, my `.mage.yml` would look like so:

```yaml
magephp:
    subscribers:
        - Vendor\MageExtension\SshCommandProviderEventSubscriber
```

```php
class SshCommandProviderEventSubscriber implements EventSubscriberInterface
{
    public function registerCommands(RegisterCommandsEvent $event)
    {
        $event->addCommand(new SshCommand());
    }

    public static function getSubscribedEvents(): array
    {
        return [
            RegisterCommandsEvent::EVENT_NAME => ['registerCommands'],
        ];
    }
}
```

Then I can use `vendor/bin/mage ssh` 😄 

No tests yet, I would like to know your thoughts about the concept!