### PR TITLE
Fixed tar archive from-path 

### DIFF
--- a/src/Task/BuiltIn/Deploy/Tar/PrepareTask.php
+++ b/src/Task/BuiltIn/Deploy/Tar/PrepareTask.php
@@ -43,7 +43,12 @@ class PrepareTask extends AbstractTask
         $excludes = $this->getExcludes();
         $tarPath = $this->runtime->getEnvOption('tar_create_path', 'tar');
         $flags = $this->runtime->getEnvOption('tar_create', 'cfzp');
-        $from = $this->runtime->getEnvOption('from', './');
+        $from = './';
+
+        if ($fromPath = $this->runtime->getEnvOption('from', false)) {
+            $from = '-C '.$fromPath.' '.$from;
+        }
+
         $cmdTar = sprintf('%s %s %s %s %s', $tarPath, $flags, $tarLocal, $excludes, $from);
 
         /** @var Process $process */

--- a/tests/Command/BuiltIn/DeployCommandWithReleasesTest.php
+++ b/tests/Command/BuiltIn/DeployCommandWithReleasesTest.php
@@ -139,7 +139,7 @@ class DeployCommandWithReleasesTest extends TestCase
             2 => 'git pull',
             3 => 'composer install --optimize-autoloader',
             4 => 'composer dump-autoload --optimize',
-            5 => 'tar cfzp /tmp/mageXYZ --exclude=".git" --exclude="./var/cache/*" --exclude="./var/log/*" --exclude="./web/app_dev.php" ./dist',
+            5 => 'tar cfzp /tmp/mageXYZ --exclude=".git" --exclude="./var/cache/*" --exclude="./var/log/*" --exclude="./web/app_dev.php" -C ./dist ./',
             6 => 'ssh -p 22 -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no tester@testhost "mkdir -p /var/www/test/releases/1234567890"',
             7 => 'scp -P 22 -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no /tmp/mageXYZ tester@testhost:/var/www/test/releases/1234567890/mageXYZ',
             8 => 'ssh -p 22 -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no tester@testhost "cd /var/www/test/releases/1234567890 && tar xfzop mageXYZ"',


### PR DESCRIPTION
When deploying with releases, Mage creates a TAR file for the given files. If a `from` path is specified, the TAR file contains a root folder for the given path. When extracting, this creates a folder for the `from` paths.

I'm pretty sure this is unwanted, and does not happen for Rsync.