### PR TITLE
Use fallback for posix_getpwuid on Windows

### DIFF
--- a/src/Runtime/Runtime.php
+++ b/src/Runtime/Runtime.php
@@ -517,6 +517,11 @@ class Runtime
      */
     public function getCurrentUser()
     {
+        // Windows fallback
+        if (!function_exists('posix_getpwuid')) {
+            return getenv('USERNAME') ?: '';
+        }
+
         $userData = posix_getpwuid(posix_geteuid());
         return $userData['name'];
     }


### PR DESCRIPTION
With one other adjustment (see https://github.com/andres-montanez/Magallanes/issues/306#issuecomment-419921293) Magallanes seems to work without an issue under Windows, at least under the Windows Git Bash.

The only change I had to make in the source of Magallanes is to provide this fallback for `posix_getpwuid`, which is of course not present on the Windows platform.