### PR TITLE
[RFC] do not use PHP_EOL for remote data

### DIFF
--- a/src/Command/BuiltIn/Releases/ListCommand.php
+++ b/src/Command/BuiltIn/Releases/ListCommand.php
@@ -97,7 +97,7 @@ class ListCommand extends AbstractCommand
 
                     $releases = [];
                     if (trim($process->getOutput()) != '') {
-                        $releases = explode(PHP_EOL, trim($process->getOutput()));
+                        $releases = explode("\n", trim($process->getOutput()));
                         rsort($releases);
                     }
 

--- a/src/Command/BuiltIn/Releases/RollbackCommand.php
+++ b/src/Command/BuiltIn/Releases/RollbackCommand.php
@@ -120,7 +120,7 @@ class RollbackCommand extends DeployCommand
             /** @var Process $process */
             $process = $this->runtime->runRemoteCommand($cmdListReleases, false);
             if ($process->isSuccessful()) {
-                $releases = explode(PHP_EOL, trim($process->getOutput()));
+                $releases = explode("\n", trim($process->getOutput()));
                 rsort($releases);
             }
 

--- a/src/Task/BuiltIn/Composer/SelfUpdateTask.php
+++ b/src/Task/BuiltIn/Composer/SelfUpdateTask.php
@@ -61,7 +61,7 @@ class SelfUpdateTask extends AbstractComposerTask
     protected function getBuildDate($output)
     {
         $buildDate = null;
-        $output = explode(PHP_EOL, $output);
+        $output = explode("\n", $output);
         foreach ($output as $row) {
             if (strpos($row, 'Composer version ') === 0) {
                 $buildDate = DateTime::createFromFormat('Y-m-d H:i:s', substr(trim($row), -19));

--- a/src/Task/BuiltIn/Deploy/Release/CleanupTask.php
+++ b/src/Task/BuiltIn/Deploy/Release/CleanupTask.php
@@ -42,7 +42,7 @@ class CleanupTask extends AbstractTask
         $process = $this->runtime->runRemoteCommand($cmdListReleases, false);
         if ($process->isSuccessful()) {
             $releases = $process->getOutput();
-            $releases = explode(PHP_EOL, trim($releases));
+            $releases = explode("\n", trim($releases));
 
             if (count($releases) > $maxReleases) {
                 sort($releases);

--- a/tests/Runtime/ProcessMockup.php
+++ b/tests/Runtime/ProcessMockup.php
@@ -98,7 +98,7 @@ class ProcessMockup extends Process
         }
 
         if ($this->commandline == 'ssh -p 22 -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no tester@testhost "ls -1 /var/www/test/releases"') {
-            return implode(PHP_EOL, ['20170101015110', '20170101015111', '20170101015112', '20170101015113', '20170101015114', '20170101015115', '20170101015116', '20170101015117']);
+            return implode("\n", ['20170101015110', '20170101015111', '20170101015112', '20170101015113', '20170101015114', '20170101015115', '20170101015116', '20170101015117']);
         }
 
         if ($this->commandline == 'ssh -p 22 -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no tester@testhost "readlink -f /var/www/test/current"') {
@@ -106,7 +106,7 @@ class ProcessMockup extends Process
         }
 
         if ($this->commandline == 'ssh -p 202 -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no tester@testhost "ls -1 /var/www/test/releases"') {
-            return implode(PHP_EOL, ['20170101015110', '20170101015111', '20170101015112', '20170101015113', '20170101015114', '20170101015115', '20170101015116', '20170101015117']);
+            return implode("\n", ['20170101015110', '20170101015111', '20170101015112', '20170101015113', '20170101015114', '20170101015115', '20170101015116', '20170101015117']);
         }
 
         if ($this->commandline == 'ssh -p 202 -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no tester@testhost "readlink -f /var/www/test/current"') {
@@ -114,15 +114,15 @@ class ProcessMockup extends Process
         }
 
         if ($this->commandline == 'ssh -p 22 -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no tester@host1 "ls -1 /var/www/test/releases"') {
-            return implode(PHP_EOL, ['20170101015110', '20170101015111', '20170101015112', '20170101015113', '20170101015114', '20170101015115', '20170101015116', '20170101015117']);
+            return implode("\n", ['20170101015110', '20170101015111', '20170101015112', '20170101015113', '20170101015114', '20170101015115', '20170101015116', '20170101015117']);
         }
 
         if ($this->commandline == 'ssh -p 22 -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no tester@hostdemo1 "ls -1 /var/www/test/releases"') {
-            return implode(PHP_EOL, ['20170101015110', '20170101015111', '20170101015112', '20170101015113', '20170101015114', '20170101015115', '20170101015116', '20170101015117']);
+            return implode("\n", ['20170101015110', '20170101015111', '20170101015112', '20170101015113', '20170101015114', '20170101015115', '20170101015116', '20170101015117']);
         }
 
         if ($this->commandline == 'ssh -p 22 -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no tester@hostdemo3 "ls -1 /var/www/test/releases"') {
-            return implode(PHP_EOL, ['20170101015110', '20170101015111', '20170101015112', '20170101015113', '20170101015114', '20170101015116', '20170101015117']);
+            return implode("\n", ['20170101015110', '20170101015111', '20170101015112', '20170101015113', '20170101015114', '20170101015116', '20170101015117']);
         }
 
         if ($this->commandline == 'ssh -p 22 -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no tester@host2 "ls -1 /var/www/test/releases"') {


### PR DESCRIPTION
This fixes #428 

Currently Magallanes uses `PHP_EOL` for every instance where it wants to either parse or write a new 'new line character'.

However, when Magallanes is used on Windows, this breaks things like the `CleanupTask` (see #428) - if the remote host is a Unix machine (which it usually is).

The proposed solution isn't perfect and simply assumes, that the remote host will always be a Unix machine.

May be the __remote__ EOL character should be made configurable in the `.mage.yml` and simply defaults to `"\n"` otherwise. What do you think?