### PR TITLE
fix tar_create command on Windows

### DIFF
--- a/src/Task/BuiltIn/Deploy/Tar/PrepareTask.php
+++ b/src/Task/BuiltIn/Deploy/Tar/PrepareTask.php
@@ -42,7 +42,7 @@ class PrepareTask extends AbstractTask
 
         $excludes = $this->getExcludes();
         $tarPath = $this->runtime->getEnvOption('tar_create_path', 'tar');
-        $flags = $this->runtime->getEnvOption('tar_create', 'cfzp');
+        $flags = $this->runtime->getEnvOption('tar_create', stripos(PHP_OS, 'WIN') === 0 ? '--force-local -c -z -p -f' : 'cfzp');
         $from = $this->runtime->getEnvOption('from', './');
         $cmdTar = sprintf('%s %s %s %s %s', $tarPath, $flags, $tarLocal, $excludes, $from);
 


### PR DESCRIPTION
Under Windows, we need the `--force-local` argument for `tar_create` by default. Otherwise, due to the `:` in absolute Windows file paths, tar thinks that the path is on another machine - and you have to override this using `--force-local` (see also https://github.com/Microsoft/azure-pipelines-tool-lib/issues/34 for example).

Imho it is important to integrate this into Magallanes, so that a `.mage.yml` can be committed to a git repository and then used by Linux and Windows users alike. Otherwise if you put
```yml
tar_create: --force-local -c -z -p -f
```
into your `.mage.yml` it will not work for *nix users anymore - and without it it won't work for Windows users.
    