### PR TITLE
Make CopyTask scp command timeout configurable

### DIFF
--- a/src/Runtime/Runtime.php
+++ b/src/Runtime/Runtime.php
@@ -471,6 +471,10 @@ class Runtime
             $sshConfig['flags'] = '-q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no';
         }
 
+        if (!array_key_exists('timeout', $sshConfig)) {
+            $sshConfig['timeout'] = 300;
+        }
+
         return $sshConfig;
     }
 

--- a/src/Task/BuiltIn/Deploy/Tar/CopyTask.php
+++ b/src/Task/BuiltIn/Deploy/Tar/CopyTask.php
@@ -53,7 +53,7 @@ class CopyTask extends AbstractTask
         $cmdCopy = sprintf('scp -P %d %s %s %s@%s:%s/%s', $sshConfig['port'], $sshConfig['flags'], $tarLocal, $user, $host, $targetDir, $tarRemote);
 
         /** @var Process $process */
-        $process = $this->runtime->runLocalCommand($cmdCopy, 300);
+        $process = $this->runtime->runLocalCommand($cmdCopy, $sshConfig['timeout']);
         if ($process->isSuccessful()) {
             $cmdUnTar = sprintf('cd %s && %s %s %s', $targetDir, $tarPath, $flags, $tarRemote);
             $process = $this->runtime->runRemoteCommand($cmdUnTar, false, 600);

--- a/tests/Command/BuiltIn/DeployCommandWithReleasesTest.php
+++ b/tests/Command/BuiltIn/DeployCommandWithReleasesTest.php
@@ -168,6 +168,56 @@ class DeployCommandWithReleasesTest extends TestCase
         $this->assertEquals(0, $tester->getStatusCode());
     }
 
+    public function testDeploymentWithReleasesWithTimeout()
+    {
+        $application = new MageApplicationMockup(__DIR__ . '/../../Resources/testhost-with-release-timeout.yml');
+
+        $application->getRuntime()->setReleaseId('20170101015120');
+
+        /** @var AbstractCommand $command */
+        $command = $application->find('deploy');
+        $this->assertTrue($command instanceof DeployCommand);
+
+        $tester = new CommandTester($command);
+        $tester->execute(['command' => $command->getName(), 'environment' => 'test']);
+
+        $ranCommands = $application->getRuntime()->getRanCommands();
+
+        $testCase = array(
+            0 => 'git branch | grep "*"',
+            1 => 'git checkout test',
+            2 => 'git pull',
+            3 => 'composer install --optimize-autoloader',
+            4 => 'composer dump-autoload --optimize',
+            5 => 'tar cfzp /tmp/mageXYZ --exclude=".git" --exclude="./var/cache/*" --exclude="./var/log/*" --exclude="./web/app_dev.php" ./',
+            6 => 'ssh -p 22 -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no tester@testhost "mkdir -p /var/www/test/releases/1234567890"',
+            7 => 'scp -P 22 -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no /tmp/mageXYZ tester@testhost:/var/www/test/releases/1234567890/mageXYZ',
+            8 => 'ssh -p 22 -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no tester@testhost "cd /var/www/test/releases/1234567890 && tar xfzop mageXYZ"',
+            9 => 'ssh -p 22 -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no tester@testhost "rm /var/www/test/releases/1234567890/mageXYZ"',
+            10 => 'ssh -p 22 -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no tester@testhost "cd /var/www/test/releases/1234567890 && bin/console cache:warmup --env=dev"',
+            11 => 'ssh -p 22 -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no tester@testhost "cd /var/www/test/releases/1234567890 && bin/console assets:install web --env=dev --symlink --relative"',
+            12 => 'ssh -p 22 -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no tester@testhost "cd /var/www/test/releases/1234567890 && bin/console cache:pool:prune --env=dev"',
+            13 => 'ssh -p 22 -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no tester@testhost "cd /var/www/test && ln -snf releases/1234567890 current"',
+            14 => 'ssh -p 22 -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no tester@testhost "ls -1 /var/www/test/releases"',
+            15 => 'ssh -p 22 -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no tester@testhost "rm -rf /var/www/test/releases/20170101015110"',
+            16 => 'ssh -p 22 -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no tester@testhost "rm -rf /var/www/test/releases/20170101015111"',
+            17 => 'ssh -p 22 -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no tester@testhost "rm -rf /var/www/test/releases/20170101015112"',
+            18 => 'ssh -p 22 -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no tester@testhost "rm -rf /var/www/test/releases/20170101015113"',
+            19 => 'rm /tmp/mageXYZ',
+            20 => 'git checkout master',
+        );
+
+        // Check total of Executed Commands
+        $this->assertEquals(count($testCase), count($ranCommands));
+
+        // Check Generated Commands
+        foreach ($testCase as $index => $command) {
+            $this->assertEquals($command, $ranCommands[$index]);
+        }
+
+        $this->assertEquals(0, $tester->getStatusCode());
+    }
+
     public function testDeploymentWithoutReleasesTarPrepare()
     {
         $application = new MageApplicationMockup(__DIR__ . '/../../Resources/testhost-force-tar1.yml');

--- a/tests/Resources/testhost-with-release-timeout.yml
+++ b/tests/Resources/testhost-with-release-timeout.yml
@@ -1,0 +1,31 @@
+magephp:
+    log_dir: /tmp
+    environments:
+        test:
+            user: tester
+            branch: test
+            from: ./
+            host_path: /var/www/test
+            releases: 4
+            exclude:
+                - ./var/cache/*
+                - ./var/log/*
+                - ./web/app_dev.php
+                -
+                -
+            hosts:
+                - testhost
+            ssh:
+                port: 22
+                timeout: 100
+            pre-deploy:
+                - git/update
+                - composer/install
+                - composer/dump-autoload
+            on-deploy:
+                - symfony/cache-warmup: { env: 'dev' }
+                - symfony/assets-install: { env: 'dev' }
+                - symfony/cache-pool-prune: { env: 'dev' }
+            on-release:
+            post-release:
+            post-deploy:


### PR DESCRIPTION
**Use case:**
Deploying using releases will copy the tar archive to the remote server with "scp command" with a timeout maximum of 300 seconds .

**Problem:**
If you have limited upload bandwidth and/or big tar archives, the command will run into a timeout after 300 seconds.
$process = $this->runtime->runLocalCommand($cmdCopy, 300);

**Solution:**
Make the timeout for the CopyTask (scp upload command) configurable in the .mage.yml file. The default value can still be 300 seconds.