### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 Simply add the following dependency to your project’s composer.json file:
 
 ```json
-    "require": {
+    "require-dev": {
         "andres-montanez/magallanes": "^4.0"
     }
 ```


### PR DESCRIPTION
By default you probably would never want to run this tool on production? In this case it would be better to require it for --dev dependencies