### PR TITLE
Allow "monolog/monolog:^2.0"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   ],
   "require": {
     "php": "^7.1.3",
-    "monolog/monolog": "~1.11",
+    "monolog/monolog": "^1.11|^2.0",
     "symfony/console": "^4.0",
     "symfony/filesystem": "^4.0",
     "symfony/event-dispatcher": "^4.0",


### PR DESCRIPTION
The changes introduced at ["monolog/monolog:2.0"](https://github.com/Seldaek/monolog/blob/master/UPGRADE.md#200) are not breaking any implemented feature.