### PR TITLE
[FEATURE] Symfony 6 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,12 +14,12 @@
   "require": {
     "php": "^8.0",
     "monolog/monolog": "~1.11 | ^2.0",
-    "symfony/console": "^4.0 | ^5.0 | ^6.0",
-    "symfony/filesystem": "^4.0 | ^5.0 | ^6.0",
-    "symfony/event-dispatcher": "^4.0 | ^5.0 | ^6.0",
-    "symfony/finder": "^4.0 | ^5.0 | ^6.0",
-    "symfony/yaml": "^4.0 | ^5.0 | ^6.0",
-    "symfony/process": "^4.0 | ^5.0 | ^6.0"
+    "symfony/console": "^5.0 | ^6.0",
+    "symfony/filesystem": "^5.0 | ^6.0",
+    "symfony/event-dispatcher": "^5.0 | ^6.0",
+    "symfony/finder": "^5.0 | ^6.0",
+    "symfony/yaml": "^5.0 | ^6.0",
+    "symfony/process": "^5.0 | ^6.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.0",

--- a/composer.json
+++ b/composer.json
@@ -12,18 +12,19 @@
     }
   ],
   "require": {
-    "php": "^7.2 | ^8.0",
+    "php": "^8.0",
     "monolog/monolog": "~1.11 | ^2.0",
-    "symfony/console": "^4.0 | ^5.0",
-    "symfony/filesystem": "^4.0 | ^5.0",
-    "symfony/event-dispatcher": "^4.0 | ^5.0",
-    "symfony/finder": "^4.0 | ^5.0",
-    "symfony/yaml": "^4.0 | ^5.0",
-    "symfony/process": "^4.0 | ^5.0"
+    "symfony/console": "^4.0 | ^5.0 | ^6.0",
+    "symfony/filesystem": "^4.0 | ^5.0 | ^6.0",
+    "symfony/event-dispatcher": "^4.0 | ^5.0 | ^6.0",
+    "symfony/finder": "^4.0 | ^5.0 | ^6.0",
+    "symfony/yaml": "^4.0 | ^5.0 | ^6.0",
+    "symfony/process": "^4.0 | ^5.0 | ^6.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.0",
-    "php-coveralls/php-coveralls": "~2.0"
+    "php-coveralls/php-coveralls": "~2.0",
+    "symfony/phpunit-bridge": "^6.0"
   },
   "suggest": {
     "ext-posix": "*"

--- a/tests/Runtime/ProcessMockup.php
+++ b/tests/Runtime/ProcessMockup.php
@@ -24,9 +24,10 @@ class ProcessMockup extends Process
         $this->commandline = $commandline;
     }
 
-    public function setTimeout($timeout)
+    public function setTimeout(?float $timeout): static
     {
         $this->timeout = $timeout;
+        return $this;
     }
 
     public function run(callable $callback = null, array $env = array()): int
@@ -58,17 +59,17 @@ class ProcessMockup extends Process
         return 0;
     }
 
-    public function isSuccessful()
+    public function isSuccessful(): bool
     {
         return $this->success;
     }
 
-    public function getErrorOutput()
+    public function getErrorOutput(): string
     {
         return '';
     }
 
-    public function getOutput()
+    public function getOutput(): string
     {
         if ($this->commandline == 'git branch | grep "*"') {
             return '* master';


### PR DESCRIPTION
Added support for Symfony 6, so Magallanes can be used in Symfony 6 projects.

Some why's:
- Dropped support for php <8.0 because of symfony/process 6 declaring "static" as return type on a method that is overwritten bei Magallanes
- Dropped Symfony 4 from list of compatible Symfony versions, as at least Mage\Tests\Runtime\ProcessMockup::setTimeout is no longer compatible with Symfony\Component\Process\Process::setTimeout. 
- Although the contribution guide says one should start branches from `nostromo`, I've started from `master` as the former is quite dated.

Running the tests with the latest Symfony 5 and Symfony 6 packages works fine.