### PR TITLE
Fix PHP version used by testing workflow

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -19,13 +19,13 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Composer install
-        uses: php-actions/composer@v5
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
         with:
-          command: install
-          args: --ignore-platform-reqs --no-scripts
-          version: 2
-          php_version: 8.0
+          php-version: 8.0
+          tools: composer:v2
+      - name: Composer install
+        run: composer install --ignore-platform-reqs --no-scripts
       - name: PHPStan
         run: ./vendor/bin/phpstan analyse
       - name: PHP Code Sniffer

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,17 +22,18 @@ jobs:
           - php: 8.1
             coveralls: false
     steps:
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          tools: composer:v2
+          coverage: xdebug
       - name: Checkout
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
       - name: Composer install
-        uses: php-actions/composer@v5
-        with:
-          command: install
-          args: --ignore-platform-reqs --no-scripts
-          version: 2
-          php_version: ${{ matrix.php }}
+        run: composer install --ignore-platform-reqs --no-scripts
       - name: Run tests
         env:
           XDEBUG_MODE: coverage


### PR DESCRIPTION
The test workflow use the action `php-actions/composer` to install the project dependencies, specifying the PHP version that composer should use, but this action does not configure the test runner to continue using the desired PHP version.  This issue can be seen in [this example run](https://github.com/iambrosi/Magallanes/runs/6057929145?check_suite_focus=true), which simply added `php --version` before running PHPUnit:

<img width="1446" alt="image" src="https://user-images.githubusercontent.com/297102/163750905-8fecd35c-a10d-4d11-9ef1-5b038f694e1b.png">


The fix is to use the action `shivammathur/setup-php@v2` to setup the proper PHP version in the test runner, replacing `php-actions/composer` which only ensured using the desired PHP version while installing the project dependencies.